### PR TITLE
fix(ci): Remove CI/CD check differences between PR and push events

### DIFF
--- a/.changeset/fix-ci-workflow-dependencies.md
+++ b/.changeset/fix-ci-workflow-dependencies.md
@@ -1,0 +1,13 @@
+---
+'MyPackage': patch
+---
+
+Fix CI/CD check differences between pull request and push events
+
+Changes:
+
+- Add `detect-changes` job with cross-platform `detect-code-changes.mjs` script
+- Make lint job independent of changeset-check (runs based on file changes only)
+- Allow docs-only PRs without changeset requirement
+- Handle changeset-check 'skipped' state in dependent jobs
+- Exclude `.changeset/`, `docs/`, `experiments/`, `examples/` folders and markdown files from code changes detection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,45 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-  # Changeset validation - only runs on PRs
+  # === DETECT CHANGES - determines which jobs should run ===
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    outputs:
+      cs-changed: ${{ steps.changes.outputs.cs-changed }}
+      csproj-changed: ${{ steps.changes.outputs.csproj-changed }}
+      sln-changed: ${{ steps.changes.outputs.sln-changed }}
+      props-changed: ${{ steps.changes.outputs.props-changed }}
+      mjs-changed: ${{ steps.changes.outputs.mjs-changed }}
+      docs-changed: ${{ steps.changes.outputs.docs-changed }}
+      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
+      any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Detect changes
+        id: changes
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bun run scripts/detect-code-changes.mjs
+
+  # === CHANGESET CHECK - only runs on PRs with code changes ===
+  # Docs-only PRs (./docs folder, markdown files) don't require changesets
   changeset-check:
     name: Changeset Validation
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: [detect-changes]
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,12 +103,23 @@ jobs:
           # Run changeset validation script
           bun run scripts/validate-changeset.mjs
 
-  # Linting and formatting - runs after changeset check on PRs, immediately on main
+  # === LINT AND FORMAT CHECK ===
+  # Lint runs independently of changeset-check - it's a fast check that should always run
+  # See: https://github.com/link-foundation/js-ai-driven-development-pipeline-template/pull/18 for why this dependency was removed
   lint:
     name: Lint and Format Check
     runs-on: ubuntu-latest
-    needs: [changeset-check]
-    if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changeset-check.result == 'success')
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.cs-changed == 'true' ||
+      needs.detect-changes.outputs.csproj-changed == 'true' ||
+      needs.detect-changes.outputs.sln-changed == 'true' ||
+      needs.detect-changes.outputs.props-changed == 'true' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.docs-changed == 'true' ||
+      needs.detect-changes.outputs.workflow-changed == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -100,12 +145,13 @@ jobs:
       - name: Check file size limit
         run: bun run scripts/check-file-size.mjs
 
-  # Test on multiple OS
+  # === TEST ON MULTIPLE OS ===
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: [changeset-check]
-    if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changeset-check.result == 'success')
+    needs: [detect-changes, changeset-check]
+    # Run if: push event, workflow_dispatch, OR changeset-check succeeded, OR changeset-check was skipped (docs-only PR)
+    if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -133,7 +179,8 @@ jobs:
         with:
           fail_ci_if_error: false
 
-  # Build package - only runs if lint and test pass
+  # === BUILD PACKAGE ===
+  # Only runs if lint and test pass
   build:
     name: Build Package
     runs-on: ubuntu-latest
@@ -162,7 +209,8 @@ jobs:
           name: nuget-package
           path: ./artifacts/*.nupkg
 
-  # Automatic release on push to main (using changesets)
+  # === AUTOMATIC RELEASE ===
+  # Runs on push to main using changesets
   release:
     name: Release
     needs: [lint, test, build]
@@ -233,7 +281,8 @@ jobs:
             --release-version "${{ steps.version.outputs.new_version }}" \
             --repository "${{ github.repository }}"
 
-  # Manual instant release via workflow_dispatch
+  # === MANUAL INSTANT RELEASE ===
+  # Triggered via workflow_dispatch with instant mode
   instant-release:
     name: Instant Release
     needs: [lint, test, build]
@@ -293,7 +342,8 @@ jobs:
             --release-version "${{ steps.version.outputs.new_version }}" \
             --repository "${{ github.repository }}"
 
-  # Manual changeset PR - creates a pull request with the changeset for review
+  # === MANUAL CHANGESET PR ===
+  # Creates a pull request with the changeset for review
   changeset-pr:
     name: Create Changeset PR
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changeset-pr'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/3
+Your prepared branch: issue-3-e7a11fc0a4e7
+Your prepared working directory: /tmp/gh-issue-solver-1767016262399
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/3
-Your prepared branch: issue-3-e7a11fc0a4e7
-Your prepared working directory: /tmp/gh-issue-solver-1767016262399
-
-Proceed.

--- a/scripts/detect-code-changes.mjs
+++ b/scripts/detect-code-changes.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+/**
+ * Detect code changes for CI/CD pipeline
+ *
+ * This script detects what types of files have changed between two commits
+ * and outputs the results for use in GitHub Actions workflow conditions.
+ *
+ * Key behavior:
+ * - For PRs: compares PR head against base branch
+ * - For pushes: compares HEAD against HEAD^
+ * - Excludes certain folders and file types from "code changes" detection
+ *
+ * Excluded from code changes (don't require changesets):
+ * - Markdown files (*.md) in any folder
+ * - .changeset/ folder (changeset metadata)
+ * - docs/ folder (documentation)
+ * - experiments/ folder (experimental scripts)
+ * - examples/ folder (example scripts)
+ *
+ * Usage:
+ *   bun run scripts/detect-code-changes.mjs
+ *
+ * Environment variables (set by GitHub Actions):
+ *   - GITHUB_EVENT_NAME: 'pull_request' or 'push'
+ *   - GITHUB_BASE_SHA: Base commit SHA for PR
+ *   - GITHUB_HEAD_SHA: Head commit SHA for PR
+ *
+ * Outputs (written to GITHUB_OUTPUT):
+ *   - cs-changed: 'true' if any .cs files changed
+ *   - csproj-changed: 'true' if any .csproj files changed
+ *   - sln-changed: 'true' if any .sln files changed
+ *   - props-changed: 'true' if any .props files changed (Directory.Build.props etc.)
+ *   - mjs-changed: 'true' if any .mjs files changed (scripts)
+ *   - docs-changed: 'true' if any .md files changed
+ *   - workflow-changed: 'true' if any .github/workflows/ files changed
+ *   - any-code-changed: 'true' if any code files changed (excludes docs, changesets, experiments, examples)
+ */
+
+import { execSync } from 'child_process';
+import { appendFileSync } from 'fs';
+
+/**
+ * Execute a shell command and return trimmed output
+ * @param {string} command - The command to execute
+ * @returns {string} - The trimmed command output
+ */
+function exec(command) {
+  try {
+    return execSync(command, { encoding: 'utf-8' }).trim();
+  } catch (error) {
+    console.error(`Error executing command: ${command}`);
+    console.error(error.message);
+    return '';
+  }
+}
+
+/**
+ * Write output to GitHub Actions output file
+ * @param {string} name - Output name
+ * @param {string} value - Output value
+ */
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${name}=${value}\n`);
+  }
+  console.log(`${name}=${value}`);
+}
+
+/**
+ * Get the list of changed files between two commits
+ * @returns {string[]} Array of changed file paths
+ */
+function getChangedFiles() {
+  const eventName = process.env.GITHUB_EVENT_NAME || 'local';
+
+  if (eventName === 'pull_request') {
+    const baseSha = process.env.GITHUB_BASE_SHA;
+    const headSha = process.env.GITHUB_HEAD_SHA;
+
+    if (baseSha && headSha) {
+      console.log(`Comparing PR: ${baseSha}...${headSha}`);
+      try {
+        // Ensure we have the base commit
+        try {
+          execSync(`git cat-file -e ${baseSha}`, { stdio: 'ignore' });
+        } catch {
+          console.log('Base commit not available locally, attempting fetch...');
+          execSync(`git fetch origin ${baseSha}`, { stdio: 'inherit' });
+        }
+        const output = exec(`git diff --name-only ${baseSha} ${headSha}`);
+        return output ? output.split('\n').filter(Boolean) : [];
+      } catch (error) {
+        console.error(`Git diff failed: ${error.message}`);
+      }
+    }
+  }
+
+  // For push events or fallback
+  console.log('Comparing HEAD^ to HEAD');
+  try {
+    const output = exec('git diff --name-only HEAD^ HEAD');
+    return output ? output.split('\n').filter(Boolean) : [];
+  } catch {
+    // If HEAD^ doesn't exist (first commit), list all files in HEAD
+    console.log('HEAD^ not available, listing all files in HEAD');
+    const output = exec('git ls-tree --name-only -r HEAD');
+    return output ? output.split('\n').filter(Boolean) : [];
+  }
+}
+
+/**
+ * Check if a file should be excluded from code changes detection
+ * @param {string} filePath - The file path to check
+ * @returns {boolean} True if the file should be excluded
+ */
+function isExcludedFromCodeChanges(filePath) {
+  // Exclude markdown files in any folder
+  if (filePath.endsWith('.md')) {
+    return true;
+  }
+
+  // Exclude specific folders from code changes
+  const excludedFolders = ['.changeset/', 'docs/', 'experiments/', 'examples/'];
+
+  for (const folder of excludedFolders) {
+    if (filePath.startsWith(folder)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Main function to detect changes
+ */
+function detectChanges() {
+  console.log('Detecting file changes for CI/CD...\n');
+
+  const changedFiles = getChangedFiles();
+
+  console.log('Changed files:');
+  if (changedFiles.length === 0) {
+    console.log('  (none)');
+  } else {
+    changedFiles.forEach((file) => console.log(`  ${file}`));
+  }
+  console.log('');
+
+  // Detect .cs file changes (C# source files)
+  const csChanged = changedFiles.some((file) => file.endsWith('.cs'));
+  setOutput('cs-changed', csChanged ? 'true' : 'false');
+
+  // Detect .csproj file changes (project files)
+  const csprojChanged = changedFiles.some((file) => file.endsWith('.csproj'));
+  setOutput('csproj-changed', csprojChanged ? 'true' : 'false');
+
+  // Detect .sln file changes (solution files)
+  const slnChanged = changedFiles.some((file) => file.endsWith('.sln'));
+  setOutput('sln-changed', slnChanged ? 'true' : 'false');
+
+  // Detect .props file changes (Directory.Build.props, etc.)
+  const propsChanged = changedFiles.some((file) => file.endsWith('.props'));
+  setOutput('props-changed', propsChanged ? 'true' : 'false');
+
+  // Detect .mjs file changes (scripts)
+  const mjsChanged = changedFiles.some((file) => file.endsWith('.mjs'));
+  setOutput('mjs-changed', mjsChanged ? 'true' : 'false');
+
+  // Detect documentation changes (any .md file)
+  const docsChanged = changedFiles.some((file) => file.endsWith('.md'));
+  setOutput('docs-changed', docsChanged ? 'true' : 'false');
+
+  // Detect workflow changes
+  const workflowChanged = changedFiles.some((file) =>
+    file.startsWith('.github/workflows/')
+  );
+  setOutput('workflow-changed', workflowChanged ? 'true' : 'false');
+
+  // Detect code changes (excluding docs, changesets, experiments, examples folders, and markdown files)
+  const codeChangedFiles = changedFiles.filter(
+    (file) => !isExcludedFromCodeChanges(file)
+  );
+
+  console.log('\nFiles considered as code changes:');
+  if (codeChangedFiles.length === 0) {
+    console.log('  (none)');
+  } else {
+    codeChangedFiles.forEach((file) => console.log(`  ${file}`));
+  }
+  console.log('');
+
+  // Check if any code files changed (.cs, .csproj, .sln, .props, .mjs, .json, .yml, .yaml, or workflow files)
+  const codePattern = /\.(cs|csproj|sln|props|mjs|json|yml|yaml)$|\.github\/workflows\//;
+  const codeChanged = codeChangedFiles.some((file) => codePattern.test(file));
+  setOutput('any-code-changed', codeChanged ? 'true' : 'false');
+
+  console.log('\nChange detection completed.');
+}
+
+// Run the detection
+detectChanges();


### PR DESCRIPTION
## Summary

This PR applies best practices from [js-ai-driven-development-pipeline-template#18](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/pull/18) to fix the issue where CI/CD checks behave differently for pull request events vs push/merge events.

### Root Cause

When documentation-only PRs are merged without changesets:
1. The `changeset-check` job fails with "No changeset found"
2. The `lint` job depends on `changeset-check` succeeding
3. Formatting/build checks never run on these PRs
4. After merge, the push to main triggers `lint`, which could fail on unformatted files

### Changes

**New Script:**
- Created `scripts/detect-code-changes.mjs` - a cross-platform JavaScript script for detecting file changes in CI/CD
- Adapted for C# projects (detects `.cs`, `.csproj`, `.sln`, `.props` files)
- Replaces need for inline bash scripts for better maintainability and cross-platform support

**Workflow Changes:**
- Add `detect-changes` job that runs the new script and outputs what types of files changed
- Make `lint` job **independent** of `changeset-check` - it's a fast check that should always run
- Make `changeset-check` **skip for docs-only PRs** by adding condition: `needs.detect-changes.outputs.any-code-changed == 'true'`
- Add `|| needs.changeset-check.result == 'skipped'` to `test` job to handle the new skipped state
- **Update `any-code-changed` detection** to exclude:
  - `.changeset/` folder (changeset metadata)
  - `docs/` folder (documentation)
  - `experiments/` folder (experimental scripts)
  - `examples/` folder (example scripts)
  - All markdown files (`*.md`) in any folder

### Benefits

After this fix:
1. **Formatting/build checks run on ALL PRs** regardless of changeset status
2. **Docs-only PRs don't require changesets** (reducing friction for documentation updates)
3. **No differences between PR checks and push/merge checks** (preventing future surprises)
4. **Changeset validation only runs when code changes** (more sensible behavior)
5. **Cross-platform compatible** - the detection script is written in JavaScript (.mjs)

### Testing

Local checks:
- ✅ `dotnet format --verify-no-changes` passes
- ✅ `dotnet build --configuration Release /warnaserror` passes
- ✅ `dotnet test --configuration Release` passes (21 tests)
- ✅ `bun run scripts/detect-code-changes.mjs` runs correctly

### Files Changed

- `.github/workflows/release.yml` - Workflow structure updates + use new script
- `scripts/detect-code-changes.mjs` - **NEW** Cross-platform change detection script
- `.changeset/fix-ci-workflow-dependencies.md` - Changeset for release

Fixes #3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)