### PR TITLE
Fix C# release metadata and NuGet verification

### DIFF
--- a/.changeset/fix-csharp-release-format.md
+++ b/.changeset/fix-csharp-release-format.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Fix C# release metadata by using language-prefixed GitHub release titles, adding a NuGet badge, and verifying NuGet propagation before release creation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,9 @@ jobs:
       - name: Build with warnings as errors
         run: dotnet build --no-restore --configuration Release /warnaserror
 
+      - name: Run script tests
+        run: bun test scripts/*.test.mjs
+
       - name: Check file size limit
         run: bun run scripts/check-file-size.mjs
 
@@ -254,23 +257,61 @@ jobs:
         id: version
         run: bun run scripts/version-and-commit.mjs --mode changeset
 
-      - name: Download artifacts
+      - name: Build release package
         if: steps.version.outputs.version_committed == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: nuget-package
-          path: ./artifacts
+        run: |
+          dotnet restore
+          dotnet build --configuration Release
+          dotnet pack --no-build --configuration Release --output ./artifacts
+
+      - name: Resolve NuGet package id
+        if: steps.version.outputs.version_committed == 'true'
+        id: package
+        run: |
+          PACKAGE_ID=$(dotnet msbuild src/MyPackage/MyPackage.csproj -getProperty:PackageId | tail -n 1 | tr -d '\r')
+          if [ -z "$PACKAGE_ID" ]; then
+            PACKAGE_ID=$(dotnet msbuild src/MyPackage/MyPackage.csproj -getProperty:AssemblyName | tail -n 1 | tr -d '\r')
+          fi
+          if [ -z "$PACKAGE_ID" ]; then
+            PACKAGE_ID="MyPackage"
+          fi
+          PACKAGE_ID_LOWER=$(echo "$PACKAGE_ID" | tr '[:upper:]' '[:lower:]')
+          echo "id=$PACKAGE_ID" >> "$GITHUB_OUTPUT"
+          echo "flat_container_id=$PACKAGE_ID_LOWER" >> "$GITHUB_OUTPUT"
 
       - name: Publish to NuGet
+        id: nuget_publish
         if: steps.version.outputs.version_committed == 'true'
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           if [ -n "$NUGET_API_KEY" ]; then
             dotnet nuget push ./artifacts/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+            echo "published=true" >> "$GITHUB_OUTPUT"
           else
             echo "NUGET_API_KEY not set, skipping NuGet publish"
+            echo "published=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Verify package on NuGet
+        if: steps.version.outputs.version_committed == 'true' && steps.nuget_publish.outputs.published == 'true'
+        run: |
+          PACKAGE_ID="${{ steps.package.outputs.id }}"
+          PACKAGE_ID_LOWER="${{ steps.package.outputs.flat_container_id }}"
+          VERSION="${{ steps.version.outputs.new_version }}"
+          for DELAY in 0 5 10 20 30 60; do
+            if [ "$DELAY" != "0" ]; then
+              sleep "$DELAY"
+            fi
+            STATUS=$(curl -sS -o /dev/null -w '%{http_code}' "https://api.nuget.org/v3-flatcontainer/${PACKAGE_ID_LOWER}/${VERSION}/${PACKAGE_ID_LOWER}.nuspec" || true)
+            echo "NuGet status for ${PACKAGE_ID}@${VERSION}: ${STATUS}"
+            if [ "$STATUS" = "200" ]; then
+              echo "Verified ${PACKAGE_ID}@${VERSION} is available on NuGet"
+              exit 0
+            fi
+          done
+          echo "::error title=NuGet verification failed::${PACKAGE_ID}@${VERSION} was not available from NuGet after publish."
+          exit 1
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true'
@@ -279,7 +320,10 @@ jobs:
         run: |
           bun run scripts/create-github-release.mjs \
             --release-version "${{ steps.version.outputs.new_version }}" \
-            --repository "${{ github.repository }}"
+            --repository "${{ github.repository }}" \
+            --tag-prefix "csharp_v" \
+            --language "C#" \
+            --package-id "${{ steps.package.outputs.id }}"
 
   # === MANUAL INSTANT RELEASE ===
   # Triggered via workflow_dispatch with instant mode
@@ -322,16 +366,54 @@ jobs:
           dotnet build --configuration Release
           dotnet pack --no-build --configuration Release --output ./artifacts
 
+      - name: Resolve NuGet package id
+        if: steps.version.outputs.version_committed == 'true'
+        id: package
+        run: |
+          PACKAGE_ID=$(dotnet msbuild src/MyPackage/MyPackage.csproj -getProperty:PackageId | tail -n 1 | tr -d '\r')
+          if [ -z "$PACKAGE_ID" ]; then
+            PACKAGE_ID=$(dotnet msbuild src/MyPackage/MyPackage.csproj -getProperty:AssemblyName | tail -n 1 | tr -d '\r')
+          fi
+          if [ -z "$PACKAGE_ID" ]; then
+            PACKAGE_ID="MyPackage"
+          fi
+          PACKAGE_ID_LOWER=$(echo "$PACKAGE_ID" | tr '[:upper:]' '[:lower:]')
+          echo "id=$PACKAGE_ID" >> "$GITHUB_OUTPUT"
+          echo "flat_container_id=$PACKAGE_ID_LOWER" >> "$GITHUB_OUTPUT"
+
       - name: Publish to NuGet
+        id: nuget_publish
         if: steps.version.outputs.version_committed == 'true'
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           if [ -n "$NUGET_API_KEY" ]; then
             dotnet nuget push ./artifacts/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+            echo "published=true" >> "$GITHUB_OUTPUT"
           else
             echo "NUGET_API_KEY not set, skipping NuGet publish"
+            echo "published=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Verify package on NuGet
+        if: steps.version.outputs.version_committed == 'true' && steps.nuget_publish.outputs.published == 'true'
+        run: |
+          PACKAGE_ID="${{ steps.package.outputs.id }}"
+          PACKAGE_ID_LOWER="${{ steps.package.outputs.flat_container_id }}"
+          VERSION="${{ steps.version.outputs.new_version }}"
+          for DELAY in 0 5 10 20 30 60; do
+            if [ "$DELAY" != "0" ]; then
+              sleep "$DELAY"
+            fi
+            STATUS=$(curl -sS -o /dev/null -w '%{http_code}' "https://api.nuget.org/v3-flatcontainer/${PACKAGE_ID_LOWER}/${VERSION}/${PACKAGE_ID_LOWER}.nuspec" || true)
+            echo "NuGet status for ${PACKAGE_ID}@${VERSION}: ${STATUS}"
+            if [ "$STATUS" = "200" ]; then
+              echo "Verified ${PACKAGE_ID}@${VERSION} is available on NuGet"
+              exit 0
+            fi
+          done
+          echo "::error title=NuGet verification failed::${PACKAGE_ID}@${VERSION} was not available from NuGet after publish."
+          exit 1
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true'
@@ -340,7 +422,10 @@ jobs:
         run: |
           bun run scripts/create-github-release.mjs \
             --release-version "${{ steps.version.outputs.new_version }}" \
-            --repository "${{ github.repository }}"
+            --repository "${{ github.repository }}" \
+            --tag-prefix "csharp_v" \
+            --language "C#" \
+            --package-id "${{ steps.package.outputs.id }}"
 
   # === MANUAL CHANGESET PR ===
   # Creates a pull request with the changeset for review

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T20:38:52.842Z for PR creation at branch issue-5-9e6b9de75773 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/5

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T20:38:52.842Z for PR creation at branch issue-5-9e6b9de75773 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/5

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -1,90 +1,386 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 /**
  * Create GitHub Release from CHANGELOG.md
- * Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository>
+ * Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--package-id <id>]
  */
 
-import { readFileSync, existsSync } from 'fs';
-import { execSync } from 'child_process';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-// Simple argument parsing
-const args = process.argv.slice(2);
-const getArg = (name) => {
-  const index = args.indexOf(`--${name}`);
-  if (index === -1) return null;
-  return args[index + 1];
-};
+const USAGE =
+  'Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--package-id <id>]';
 
-const version = getArg('release-version');
-const repository = getArg('repository');
+/**
+ * Parse CLI arguments.
+ * @param {string[]} argv
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {{releaseVersion: string, repository: string, tagPrefix: string, language: string, packageId: string}}
+ */
+export function parseArgs(argv, env = process.env) {
+  const config = {
+    language: env.LANGUAGE ?? 'C#',
+    packageId: env.PACKAGE_ID ?? '',
+    releaseVersion: env.VERSION ?? '',
+    repository: env.REPOSITORY ?? '',
+    tagPrefix: env.TAG_PREFIX ?? 'csharp_v',
+  };
 
-if (!version || !repository) {
-  console.error('Error: Missing required arguments');
-  console.error(
-    'Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository>'
-  );
-  process.exit(1);
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+
+    if (arg === '--release-version' || arg === '--version') {
+      config.releaseVersion = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--release-version=')) {
+      config.releaseVersion = arg.slice('--release-version='.length);
+    } else if (arg.startsWith('--version=')) {
+      config.releaseVersion = arg.slice('--version='.length);
+    } else if (arg === '--repository') {
+      config.repository = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--repository=')) {
+      config.repository = arg.slice('--repository='.length);
+    } else if (arg === '--tag-prefix') {
+      config.tagPrefix = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--tag-prefix=')) {
+      config.tagPrefix = arg.slice('--tag-prefix='.length);
+    } else if (arg === '--language') {
+      config.language = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--language=')) {
+      config.language = arg.slice('--language='.length);
+    } else if (arg === '--package-id') {
+      config.packageId = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--package-id=')) {
+      config.packageId = arg.slice('--package-id='.length);
+    }
+  }
+
+  return config;
 }
 
-const tag = `v${version}`;
+/**
+ * Read a CLI option value.
+ * @param {string[]} argv
+ * @param {number} index
+ * @param {string} optionName
+ * @returns {string}
+ */
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
 
-console.log(`Creating GitHub release for ${tag}...`);
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+
+  return value;
+}
+
+/**
+ * Escape text for a regular expression.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Normalize release versions to bare semver.
+ * @param {string} releaseVersion
+ * @returns {string}
+ */
+export function normalizeReleaseVersion(releaseVersion) {
+  const trimmedVersion = String(releaseVersion ?? '').trim();
+  const semverTagMatch = trimmedVersion.match(
+    /(?:^|[-_])v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/i
+  );
+
+  if (semverTagMatch) {
+    return semverTagMatch[1];
+  }
+
+  return trimmedVersion
+    .replace(/^[A-Za-z][A-Za-z0-9]*[-_]/, '')
+    .replace(/^v/i, '');
+}
+
+/**
+ * Build a release tag.
+ * @param {string} tagPrefix
+ * @param {string} releaseVersion
+ * @returns {string}
+ */
+export function buildReleaseTag(tagPrefix, releaseVersion) {
+  return `${tagPrefix}${normalizeReleaseVersion(releaseVersion)}`;
+}
+
+/**
+ * Build a release title.
+ * @param {string} language
+ * @param {string} releaseVersion
+ * @returns {string}
+ */
+export function buildReleaseTitle(language, releaseVersion) {
+  const releaseLanguage = language.trim() || 'C#';
+  return `[${releaseLanguage}] ${normalizeReleaseVersion(releaseVersion)}`;
+}
+
+/**
+ * Build a NuGet badge markdown link.
+ * @param {string} packageId
+ * @returns {string}
+ */
+export function buildNuGetBadge(packageId) {
+  const encodedPackageId = encodeURIComponent(packageId);
+  return `[![NuGet](https://img.shields.io/nuget/v/${encodedPackageId}.svg)](https://www.nuget.org/packages/${encodedPackageId})`;
+}
+
+/**
+ * Append a NuGet badge unless release notes already include a shields.io badge.
+ * @param {string} releaseNotes
+ * @param {string} packageId
+ * @returns {string}
+ */
+export function appendNuGetBadgeIfMissing(releaseNotes, packageId) {
+  if (!packageId || /img\.shields\.io/i.test(releaseNotes)) {
+    return releaseNotes;
+  }
+
+  return `${releaseNotes}\n\n---\n\n${buildNuGetBadge(packageId)}`;
+}
 
 /**
  * Extract changelog content for a specific version
+ * @param {string} changelog
  * @param {string} version
  * @returns {string}
  */
-function getChangelogForVersion(version) {
-  const changelogPath = 'CHANGELOG.md';
-
-  if (!existsSync(changelogPath)) {
-    return `Release v${version}`;
-  }
-
-  const content = readFileSync(changelogPath, 'utf-8');
+export function extractReleaseNotes(changelog, version) {
+  const semver = normalizeReleaseVersion(version);
 
   // Find the section for this version
-  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedVersion = escapeRegex(semver);
   const pattern = new RegExp(
-    `## \\[${escapedVersion}\\].*?\\n([\\s\\S]*?)(?=\\n## \\[|$)`
+    `(?:^|\\n)## \\[?${escapedVersion}\\]?[^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[?\\d|$)`
   );
-  const match = content.match(pattern);
+  const match = changelog.match(pattern);
 
   if (match) {
-    return match[1].trim();
+    const releaseNotes = match[1].trim();
+    return releaseNotes || `Release ${semver}`;
   }
 
-  return `Release v${version}`;
+  return `Release ${semver}`;
 }
 
-try {
-  const releaseNotes = getChangelogForVersion(version);
+/**
+ * Find a package id by scanning project files.
+ * @param {string} rootDir
+ * @returns {string}
+ */
+export function findPackageId(rootDir = '.') {
+  const candidates = [];
 
-  // Create release using gh CLI
-  const payload = JSON.stringify({
-    tag_name: tag,
-    name: `v${version}`,
-    body: releaseNotes,
-  });
+  walkProjectFiles(rootDir, candidates);
 
-  try {
-    execSync(`gh api repos/${repository}/releases -X POST --input -`, {
-      input: payload,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'inherit', 'inherit'],
-    });
-    console.log(`Created GitHub release: ${tag}`);
-  } catch (error) {
-    // Check if release already exists
-    if (error.message && error.message.includes('already exists')) {
-      console.log(`Release ${tag} already exists, skipping`);
-    } else {
-      throw error;
+  for (const csprojPath of candidates) {
+    const csproj = readFileSync(csprojPath, 'utf-8');
+    const packageIdMatch = csproj.match(/<PackageId>([^<]+)<\/PackageId>/);
+    if (packageIdMatch) {
+      return packageIdMatch[1].trim();
+    }
+
+    const assemblyNameMatch = csproj.match(
+      /<AssemblyName>([^<]+)<\/AssemblyName>/
+    );
+    if (assemblyNameMatch) {
+      return assemblyNameMatch[1].trim();
     }
   }
-} catch (error) {
-  console.error('Error creating release:', error.message);
-  process.exit(1);
+
+  if (candidates.length > 0) {
+    return path.basename(candidates[0], '.csproj');
+  }
+
+  return '';
+}
+
+/**
+ * Walk project files under a root directory.
+ * @param {string} dir
+ * @param {string[]} candidates
+ * @param {number} depth
+ */
+function walkProjectFiles(dir, candidates, depth = 0) {
+  if (depth > 4) {
+    return;
+  }
+
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (
+      entry === '.git' ||
+      entry === 'bin' ||
+      entry === 'obj' ||
+      entry === 'node_modules'
+    ) {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      walkProjectFiles(fullPath, candidates, depth + 1);
+    } else if (fullPath.endsWith('.csproj')) {
+      candidates.push(fullPath);
+    }
+  }
+}
+
+/**
+ * Build the GitHub release API payload.
+ * @param {{changelog: string, language: string, packageId: string, releaseVersion: string, tagPrefix: string}} options
+ * @returns {string}
+ */
+export function buildReleasePayload({
+  changelog,
+  language,
+  packageId,
+  releaseVersion,
+  tagPrefix,
+}) {
+  const semver = normalizeReleaseVersion(releaseVersion);
+  const releaseNotes = appendNuGetBadgeIfMissing(
+    extractReleaseNotes(changelog, semver),
+    packageId
+  );
+
+  return JSON.stringify({
+    tag_name: buildReleaseTag(tagPrefix, semver),
+    name: buildReleaseTitle(language, semver),
+    body: releaseNotes,
+  });
+}
+
+/**
+ * Create a GitHub release using gh.
+ * @param {{payload: string, repository: string, spawn?: typeof spawnSync}} options
+ * @returns {{alreadyExists: boolean}}
+ */
+export function createRelease({ payload, repository, spawn = spawnSync }) {
+  const result = spawn(
+    'gh',
+    ['api', `repos/${repository}/releases`, '-X', 'POST', '--input', '-'],
+    {
+      encoding: 'utf-8',
+      input: payload,
+    }
+  );
+
+  if (result.error) {
+    throw new Error(`gh api failed to start: ${result.error.message}`);
+  }
+
+  if (result.status === 0) {
+    return { alreadyExists: false };
+  }
+
+  const output = [result.stderr, result.stdout]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .join('\n');
+
+  if (/already_exists|already exists/i.test(output)) {
+    return { alreadyExists: true };
+  }
+
+  throw new Error(`gh api failed with code ${result.status}: ${output}`);
+}
+
+/**
+ * Run the CLI.
+ * @param {{argv?: string[], cwd?: string, env?: NodeJS.ProcessEnv, spawn?: typeof spawnSync, stderr?: typeof console.error, stdout?: typeof console.log}} options
+ * @returns {number}
+ */
+export function main({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  env = process.env,
+  spawn = spawnSync,
+  stderr = console.error,
+  stdout = console.log,
+} = {}) {
+  try {
+    const { language, packageId, releaseVersion, repository, tagPrefix } =
+      parseArgs(argv, env);
+
+    if (!releaseVersion || !repository) {
+      stderr('Error: Missing required arguments');
+      stderr(USAGE);
+      return 1;
+    }
+
+    const changelogPath = path.join(cwd, 'CHANGELOG.md');
+    const changelog = existsSync(changelogPath)
+      ? readFileSync(changelogPath, 'utf-8')
+      : '';
+    const resolvedPackageId = packageId || findPackageId(cwd);
+    const tag = buildReleaseTag(tagPrefix, releaseVersion);
+    const payload = buildReleasePayload({
+      changelog,
+      language,
+      packageId: resolvedPackageId,
+      releaseVersion,
+      tagPrefix,
+    });
+
+    stdout(`Creating GitHub release for ${tag}...`);
+
+    const result = createRelease({ payload, repository, spawn });
+
+    if (result.alreadyExists) {
+      stdout(`GitHub release already exists: ${tag}, skipping`);
+      return 0;
+    }
+
+    stdout(`Created GitHub release: ${tag}`);
+    return 0;
+  } catch (error) {
+    stderr(`Error creating release: ${error.message}`);
+    return 1;
+  }
+}
+
+function isCliEntryPoint() {
+  return (
+    typeof process !== 'undefined' &&
+    process.argv?.[1] &&
+    fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  );
+}
+
+if (isCliEntryPoint()) {
+  process.exitCode = main();
 }

--- a/scripts/create-github-release.test.mjs
+++ b/scripts/create-github-release.test.mjs
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  appendNuGetBadgeIfMissing,
+  buildNuGetBadge,
+  buildReleasePayload,
+  buildReleaseTag,
+  buildReleaseTitle,
+  findPackageId,
+  normalizeReleaseVersion,
+  parseArgs,
+} from './create-github-release.mjs';
+
+describe('create-github-release helpers', () => {
+  test('parseArgs defaults to the C# release format and accepts package id', () => {
+    const config = parseArgs([
+      '--release-version',
+      '1.2.3',
+      '--repository',
+      'owner/repo',
+      '--package-id',
+      'MyPackage',
+    ]);
+
+    expect(config).toEqual({
+      language: 'C#',
+      packageId: 'MyPackage',
+      releaseVersion: '1.2.3',
+      repository: 'owner/repo',
+      tagPrefix: 'csharp_v',
+    });
+  });
+
+  test('normalizes release versions from legacy and language-prefixed tags', () => {
+    expect(normalizeReleaseVersion('csharp-v1.2.3')).toBe('1.2.3');
+    expect(normalizeReleaseVersion('csharp_v1.2.3')).toBe('1.2.3');
+    expect(normalizeReleaseVersion('v1.2.3')).toBe('1.2.3');
+    expect(normalizeReleaseVersion('1.2.3-beta.1+build.7')).toBe(
+      '1.2.3-beta.1+build.7'
+    );
+  });
+
+  test('builds C# release tags and titles from bare semver', () => {
+    expect(buildReleaseTag('csharp_v', '1.2.3')).toBe('csharp_v1.2.3');
+    expect(buildReleaseTag('csharp_v', 'csharp-v1.2.3')).toBe(
+      'csharp_v1.2.3'
+    );
+    expect(buildReleaseTitle('C#', 'csharp_v1.2.3')).toBe('[C#] 1.2.3');
+  });
+
+  test('appends a NuGet shields.io badge when release notes do not have one', () => {
+    const notes = appendNuGetBadgeIfMissing('- Fix release title', 'MyPackage');
+
+    expect(notes).toContain('- Fix release title');
+    expect(notes).toContain(
+      '[![NuGet](https://img.shields.io/nuget/v/MyPackage.svg)]'
+    );
+    expect(notes).toContain('https://www.nuget.org/packages/MyPackage');
+  });
+
+  test('does not append a second badge when release notes already contain shields.io', () => {
+    const notes = appendNuGetBadgeIfMissing(
+      `${buildNuGetBadge('MyPackage')}\n\n- Existing badge`,
+      'MyPackage'
+    );
+
+    expect(notes.match(/img\.shields\.io/g)).toHaveLength(1);
+  });
+
+  test('builds a GitHub release payload with C# title and NuGet badge', () => {
+    const payload = JSON.parse(
+      buildReleasePayload({
+        changelog: '## [1.2.3] - 2026-05-09\n\n- Fix release metadata\n',
+        language: 'C#',
+        packageId: 'MyPackage',
+        releaseVersion: '1.2.3',
+        tagPrefix: 'csharp_v',
+      })
+    );
+
+    expect(payload).toEqual({
+      tag_name: 'csharp_v1.2.3',
+      name: '[C#] 1.2.3',
+      body:
+        '- Fix release metadata\n\n---\n\n' +
+        '[![NuGet](https://img.shields.io/nuget/v/MyPackage.svg)]' +
+        '(https://www.nuget.org/packages/MyPackage)',
+    });
+  });
+
+  test('findPackageId reads PackageId from a project file', () => {
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'csharp-release-'));
+    try {
+      mkdirSync(path.join(projectRoot, 'src', 'Example'), {
+        recursive: true,
+      });
+      writeFileSync(
+        path.join(projectRoot, 'src', 'Example', 'Example.csproj'),
+        '<Project><PropertyGroup><PackageId>Example.Package</PackageId></PropertyGroup></Project>'
+      );
+
+      expect(findPackageId(projectRoot)).toBe('Example.Package');
+    } finally {
+      rmSync(projectRoot, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5.

- Updates `scripts/create-github-release.mjs` to support `--tag-prefix`, `--language`, and `--package-id`.
- Creates C# release payloads with `csharp_v<version>` tags, `[C#] <version>` titles, and a NuGet shields.io badge when the release body has no badge.
- Adds Bun tests for release title/tag normalization, NuGet badge insertion, package id detection, and payload generation.
- Adds NuGet flat-container polling after publish and before GitHub release creation in both automatic and manual release flows.

## Reproduction

Before this change, the release script always built payloads with `tag_name: v<version>`, `name: v<version>`, and the raw changelog body, so C# releases had no language-prefixed title and no NuGet badge.

## Verification

- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build --configuration Release /warnaserror`
- `dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"`
- `bun test scripts/*.test.mjs`
- `bun run scripts/check-file-size.mjs`
- `GITHUB_BASE_SHA=$(git merge-base origin/main HEAD) GITHUB_HEAD_SHA=$(git rev-parse HEAD) bun run scripts/validate-changeset.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
