### PR TITLE
release: attach .nupkg artifacts to GitHub Releases

### DIFF
--- a/.changeset/attach-nuget-release-assets.md
+++ b/.changeset/attach-nuget-release-assets.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Attach generated NuGet package artifacts to GitHub Releases during release automation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,8 @@ jobs:
             --repository "${{ github.repository }}" \
             --tag-prefix "csharp_v" \
             --language "C#" \
-            --package-id "${{ steps.package.outputs.id }}"
+            --package-id "${{ steps.package.outputs.id }}" \
+            --assets-glob "./artifacts/*.nupkg"
 
   # === MANUAL INSTANT RELEASE ===
   # Triggered via workflow_dispatch with instant mode
@@ -425,7 +426,8 @@ jobs:
             --repository "${{ github.repository }}" \
             --tag-prefix "csharp_v" \
             --language "C#" \
-            --package-id "${{ steps.package.outputs.id }}"
+            --package-id "${{ steps.package.outputs.id }}" \
+            --assets-glob "./artifacts/*.nupkg"
 
   # === MANUAL CHANGESET PR ===
   # Creates a pull request with the changeset for review

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-12T16:56:49.512Z for PR creation at branch issue-7-8bb5ffd90979 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/7

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-12T16:56:49.512Z for PR creation at branch issue-7-8bb5ffd90979 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/7

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -2,7 +2,7 @@
 
 /**
  * Create GitHub Release from CHANGELOG.md
- * Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--package-id <id>]
+ * Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--package-id <id>] [--assets-glob <glob>]
  */
 
 import { spawnSync } from 'node:child_process';
@@ -16,16 +16,17 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const USAGE =
-  'Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--package-id <id>]';
+  'Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--package-id <id>] [--assets-glob <glob>]';
 
 /**
  * Parse CLI arguments.
  * @param {string[]} argv
  * @param {NodeJS.ProcessEnv} env
- * @returns {{releaseVersion: string, repository: string, tagPrefix: string, language: string, packageId: string}}
+ * @returns {{assetsGlob: string, releaseVersion: string, repository: string, tagPrefix: string, language: string, packageId: string}}
  */
 export function parseArgs(argv, env = process.env) {
   const config = {
+    assetsGlob: env.ASSETS_GLOB ?? '',
     language: env.LANGUAGE ?? 'C#',
     packageId: env.PACKAGE_ID ?? '',
     releaseVersion: env.VERSION ?? '',
@@ -63,6 +64,11 @@ export function parseArgs(argv, env = process.env) {
       index++;
     } else if (arg.startsWith('--package-id=')) {
       config.packageId = arg.slice('--package-id='.length);
+    } else if (arg === '--assets-glob') {
+      config.assetsGlob = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--assets-glob=')) {
+      config.assetsGlob = arg.slice('--assets-glob='.length);
     }
   }
 
@@ -320,6 +326,99 @@ export function createRelease({ payload, repository, spawn = spawnSync }) {
 }
 
 /**
+ * Resolve a simple release asset glob.
+ *
+ * Supports exact file paths or `*` in the file name portion, such as
+ * `artifacts/*.nupkg`. Matches are returned in deterministic path order.
+ *
+ * @param {string} assetsGlob
+ * @param {string} cwd
+ * @returns {string[]}
+ */
+export function resolveReleaseAssets(assetsGlob, cwd = '.') {
+  const pattern = String(assetsGlob ?? '').trim();
+  if (!pattern) {
+    return [];
+  }
+
+  const absolutePattern = path.isAbsolute(pattern)
+    ? pattern
+    : path.resolve(cwd, pattern);
+  const assetDirectory = path.dirname(absolutePattern);
+  const filePattern = path.basename(absolutePattern);
+
+  if (!filePattern.includes('*')) {
+    try {
+      return existsSync(absolutePattern) && statSync(absolutePattern).isFile()
+        ? [absolutePattern]
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  let entries;
+  try {
+    entries = readdirSync(assetDirectory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const filePatternRegex = new RegExp(
+    `^${escapeRegex(filePattern).replace(/\\\*/g, '.*')}$`
+  );
+
+  return entries
+    .filter((entry) => entry.isFile() && filePatternRegex.test(entry.name))
+    .map((entry) => path.join(assetDirectory, entry.name))
+    .sort();
+}
+
+/**
+ * Upload release assets using gh.
+ * @param {{assetPaths: string[], repository: string, tag: string, spawn?: typeof spawnSync}} options
+ * @returns {void}
+ */
+export function uploadReleaseAssets({
+  assetPaths,
+  repository,
+  tag,
+  spawn = spawnSync,
+}) {
+  if (assetPaths.length === 0) {
+    return;
+  }
+
+  const result = spawn(
+    'gh',
+    [
+      'release',
+      'upload',
+      tag,
+      ...assetPaths,
+      '--clobber',
+      '--repo',
+      repository,
+    ],
+    { encoding: 'utf-8' }
+  );
+
+  if (result.error) {
+    throw new Error(`gh release upload failed to start: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const output = [result.stderr, result.stdout]
+      .filter((value) => typeof value === 'string' && value.trim())
+      .join('\n');
+
+    throw new Error(
+      `gh release upload failed with code ${result.status}: ${output}`
+    );
+  }
+}
+
+/**
  * Run the CLI.
  * @param {{argv?: string[], cwd?: string, env?: NodeJS.ProcessEnv, spawn?: typeof spawnSync, stderr?: typeof console.error, stdout?: typeof console.log}} options
  * @returns {number}
@@ -333,7 +432,14 @@ export function main({
   stdout = console.log,
 } = {}) {
   try {
-    const { language, packageId, releaseVersion, repository, tagPrefix } =
+    const {
+      assetsGlob,
+      language,
+      packageId,
+      releaseVersion,
+      repository,
+      tagPrefix,
+    } =
       parseArgs(argv, env);
 
     if (!releaseVersion || !repository) {
@@ -361,11 +467,23 @@ export function main({
     const result = createRelease({ payload, repository, spawn });
 
     if (result.alreadyExists) {
-      stdout(`GitHub release already exists: ${tag}, skipping`);
-      return 0;
+      stdout(`GitHub release already exists: ${tag}, reconciling assets`);
+    } else {
+      stdout(`Created GitHub release: ${tag}`);
     }
 
-    stdout(`Created GitHub release: ${tag}`);
+    if (assetsGlob) {
+      const assetPaths = resolveReleaseAssets(assetsGlob, cwd);
+
+      if (assetPaths.length === 0) {
+        throw new Error(`No release assets matched ${assetsGlob}`);
+      }
+
+      stdout(`Uploading ${assetPaths.length} release asset(s) to ${tag}...`);
+      uploadReleaseAssets({ assetPaths, repository, spawn, tag });
+      stdout(`Uploaded ${assetPaths.length} release asset(s) to ${tag}`);
+    }
+
     return 0;
   } catch (error) {
     stderr(`Error creating release: ${error.message}`);

--- a/scripts/create-github-release.test.mjs
+++ b/scripts/create-github-release.test.mjs
@@ -15,6 +15,7 @@ import {
   buildReleaseTag,
   buildReleaseTitle,
   findPackageId,
+  main,
   normalizeReleaseVersion,
   parseArgs,
 } from './create-github-release.mjs';
@@ -31,6 +32,7 @@ describe('create-github-release helpers', () => {
     ]);
 
     expect(config).toEqual({
+      assetsGlob: '',
       language: 'C#',
       packageId: 'MyPackage',
       releaseVersion: '1.2.3',
@@ -108,6 +110,128 @@ describe('create-github-release helpers', () => {
       );
 
       expect(findPackageId(projectRoot)).toBe('Example.Package');
+    } finally {
+      rmSync(projectRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('uploads matching NuGet package assets after creating a release', () => {
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'csharp-release-'));
+    try {
+      mkdirSync(path.join(projectRoot, 'artifacts'), { recursive: true });
+      writeFileSync(
+        path.join(projectRoot, 'CHANGELOG.md'),
+        '## [1.2.3] - 2026-05-12\n\n- Attach package assets\n'
+      );
+      writeFileSync(
+        path.join(projectRoot, 'artifacts', 'MyPackage.1.2.3.nupkg'),
+        'fake nupkg'
+      );
+      writeFileSync(
+        path.join(projectRoot, 'artifacts', 'MyPackage.1.2.3.snupkg'),
+        'symbols package'
+      );
+
+      const calls = [];
+      const stdoutMessages = [];
+      const stderrMessages = [];
+      const spawn = (command, args, options) => {
+        calls.push({ args, command, options });
+        return { status: 0, stderr: '', stdout: '' };
+      };
+
+      const exitCode = main({
+        argv: [
+          '--release-version',
+          '1.2.3',
+          '--repository',
+          'owner/repo',
+          '--assets-glob',
+          'artifacts/*.nupkg',
+        ],
+        cwd: projectRoot,
+        env: {},
+        spawn,
+        stderr: (message) => stderrMessages.push(message),
+        stdout: (message) => stdoutMessages.push(message),
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stderrMessages).toEqual([]);
+      expect(calls).toHaveLength(2);
+      expect(calls[0].command).toBe('gh');
+      expect(calls[0].args).toEqual([
+        'api',
+        'repos/owner/repo/releases',
+        '-X',
+        'POST',
+        '--input',
+        '-',
+      ]);
+      expect(calls[1].command).toBe('gh');
+      expect(calls[1].args).toEqual([
+        'release',
+        'upload',
+        'csharp_v1.2.3',
+        path.join(projectRoot, 'artifacts', 'MyPackage.1.2.3.nupkg'),
+        '--clobber',
+        '--repo',
+        'owner/repo',
+      ]);
+      expect(stdoutMessages).toContain(
+        'Uploading 1 release asset(s) to csharp_v1.2.3...'
+      );
+    } finally {
+      rmSync(projectRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('uploads matching NuGet package assets when the release already exists', () => {
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'csharp-release-'));
+    try {
+      mkdirSync(path.join(projectRoot, 'artifacts'), { recursive: true });
+      writeFileSync(
+        path.join(projectRoot, 'CHANGELOG.md'),
+        '## [1.2.3] - 2026-05-12\n\n- Attach package assets\n'
+      );
+      writeFileSync(
+        path.join(projectRoot, 'artifacts', 'MyPackage.1.2.3.nupkg'),
+        'fake nupkg'
+      );
+
+      const calls = [];
+      const stdoutMessages = [];
+      const spawn = (command, args, options) => {
+        calls.push({ args, command, options });
+        if (args[0] === 'api') {
+          return { status: 1, stderr: 'already_exists', stdout: '' };
+        }
+
+        return { status: 0, stderr: '', stdout: '' };
+      };
+
+      const exitCode = main({
+        argv: [
+          '--release-version',
+          '1.2.3',
+          '--repository',
+          'owner/repo',
+          '--assets-glob',
+          'artifacts/*.nupkg',
+        ],
+        cwd: projectRoot,
+        env: {},
+        spawn,
+        stdout: (message) => stdoutMessages.push(message),
+      });
+
+      expect(exitCode).toBe(0);
+      expect(calls).toHaveLength(2);
+      expect(calls[1].args[0]).toBe('release');
+      expect(calls[1].args[1]).toBe('upload');
+      expect(stdoutMessages).toContain(
+        'GitHub release already exists: csharp_v1.2.3, reconciling assets'
+      );
     } finally {
       rmSync(projectRoot, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary

Fixes #7.

- Adds `--assets-glob` support to `scripts/create-github-release.mjs`.
- Resolves matching package files and uploads them with `gh release upload <tag> <files...> --clobber --repo <repo>` after the release is created or when it already exists.
- Wires `--assets-glob "./artifacts/*.nupkg"` into both automatic and instant release jobs.
- Adds a patch changeset and Bun tests covering asset upload for newly created and pre-existing releases.

## Reproduction

Before this change, `dotnet pack` produced `./artifacts/*.nupkg` and `dotnet nuget push` published it to NuGet, but the GitHub Release creation step only posted release notes through `gh api`; no `.nupkg` was attached to the release assets.

## Verification

- `bun test scripts/create-github-release.test.mjs` first failed because only one `gh` call was made and no release upload occurred.
- `bun test scripts/*.test.mjs`
- `bun run scripts/check-file-size.mjs`
- `dotnet restore`
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build --no-restore --configuration Release /warnaserror`
- `dotnet test --no-build --configuration Release --verbosity normal`
- `GITHUB_BASE_REF=main bun run scripts/validate-changeset.mjs`
