### PR TITLE
fix: detect missing release tags correctly

### DIFF
--- a/.changeset/fix-missing-tag-detection.md
+++ b/.changeset/fix-missing-tag-detection.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Fix release script treating missing tags as already released. The `exec()` helper now propagates command failures even in silent mode, and `checkTagExists()` queries the exact `refs/tags/v<version>` ref, so a missing tag is no longer mistaken for an existing one.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-12T20:28:24.683Z for PR creation at branch issue-9-fdc6fb5f17ee for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/9

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-12T20:28:24.683Z for PR creation at branch issue-9-fdc6fb5f17ee for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/9

--- a/experiments/reproduce-bug.sh
+++ b/experiments/reproduce-bug.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Reproduce the bug from issue #9:
+# version-and-commit.mjs reports already_released=true for a tag that doesn't exist.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK_DIR="$(mktemp -d -t version-and-commit-repro-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Reproducer working in $WORK_DIR"
+
+cd "$WORK_DIR"
+mkdir remote.git repo
+git init -q --bare -b main remote.git
+cd repo
+git init -q -b main
+git remote add origin "$WORK_DIR/remote.git"
+git config user.email test@example.com
+git config user.name 'Test User'
+git config commit.gpgsign false
+git config tag.gpgsign false
+git commit --allow-empty -q -m 'init'
+
+mkdir -p src/MyPackage .changeset
+cat > src/MyPackage/MyPackage.csproj <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>2.3.0</Version>
+  </PropertyGroup>
+</Project>
+EOF
+
+cat > .changeset/feature.md <<'EOF'
+---
+'MyPackage': minor
+---
+
+Add a feature
+EOF
+
+git add -A
+git commit -q -m 'snapshot'
+git push -q -u origin main
+
+# Sanity check: confirm v2.4.0 does NOT exist.
+if git rev-parse --verify --quiet refs/tags/v2.4.0 >/dev/null; then
+  echo "Unexpected: tag v2.4.0 already exists"
+  exit 1
+fi
+
+# Use a fake GITHUB_OUTPUT to capture output values.
+export GITHUB_OUTPUT="$WORK_DIR/gh-output.txt"
+: > "$GITHUB_OUTPUT"
+
+set +e
+bun run "$REPO_ROOT/scripts/version-and-commit.mjs" --mode changeset
+EXIT=$?
+set -e
+
+echo "---- GITHUB_OUTPUT ----"
+cat "$GITHUB_OUTPUT"
+echo "---- exit code: $EXIT ----"
+
+if grep -q 'already_released=true' "$GITHUB_OUTPUT"; then
+  echo "BUG REPRODUCED: script reported already_released=true with no tag present"
+  exit 1
+fi
+
+if ! git rev-parse --verify --quiet refs/tags/v2.4.0 >/dev/null; then
+  echo "FAIL: expected v2.4.0 tag to be created"
+  exit 1
+fi
+if ! git log --oneline | grep -q 'chore: release v2.4.0'; then
+  echo "FAIL: expected release commit for v2.4.0"
+  exit 1
+fi
+
+echo "OK: script bumped to 2.4.0, created commit and tag"
+exit 0

--- a/scripts/version-and-commit.mjs
+++ b/scripts/version-and-commit.mjs
@@ -52,12 +52,10 @@ const description = getArg('description') || '';
  * @returns {string}
  */
 function exec(command, silent = false) {
-  try {
-    return execSync(command, { encoding: 'utf-8', stdio: silent ? 'pipe' : 'inherit' });
-  } catch (error) {
-    if (silent) return '';
-    throw error;
-  }
+  return execSync(command, {
+    encoding: 'utf-8',
+    stdio: silent ? 'pipe' : 'inherit',
+  });
 }
 
 /**
@@ -135,7 +133,7 @@ function updateCsproj(newVersion) {
  */
 function checkTagExists(version) {
   try {
-    exec(`git rev-parse v${version}`, true);
+    exec(`git rev-parse --verify --quiet refs/tags/v${version}`, true);
     return true;
   } catch {
     return false;

--- a/scripts/version-and-commit.test.mjs
+++ b/scripts/version-and-commit.test.mjs
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.join(HERE, 'version-and-commit.mjs');
+
+function git(args, cwd) {
+  execFileSync('git', args, { cwd, stdio: 'pipe', encoding: 'utf-8' });
+}
+
+function setupRepo({ startingVersion, changesetBump }) {
+  const root = mkdtempSync(path.join(tmpdir(), 'version-and-commit-'));
+  const remote = path.join(root, 'remote.git');
+  const repo = path.join(root, 'repo');
+  mkdirSync(repo);
+
+  // Initialize a bare remote so `git push` succeeds without network access.
+  execFileSync('git', ['init', '-q', '--bare', '-b', 'main', remote]);
+
+  git(['init', '-q', '-b', 'main'], repo);
+  git(['config', 'user.email', 'test@example.com'], repo);
+  git(['config', 'user.name', 'Test User'], repo);
+  git(['config', 'commit.gpgsign', 'false'], repo);
+  git(['config', 'tag.gpgsign', 'false'], repo);
+  git(['remote', 'add', 'origin', remote], repo);
+  git(['commit', '--allow-empty', '-q', '-m', 'init'], repo);
+
+  mkdirSync(path.join(repo, 'src', 'MyPackage'), { recursive: true });
+  writeFileSync(
+    path.join(repo, 'src', 'MyPackage', 'MyPackage.csproj'),
+    `<Project Sdk="Microsoft.NET.Sdk">\n  <PropertyGroup>\n    <Version>${startingVersion}</Version>\n  </PropertyGroup>\n</Project>\n`
+  );
+
+  mkdirSync(path.join(repo, '.changeset'), { recursive: true });
+  if (changesetBump) {
+    writeFileSync(
+      path.join(repo, '.changeset', 'feature.md'),
+      `---\n'MyPackage': ${changesetBump}\n---\n\nAdd a feature\n`
+    );
+  }
+
+  git(['add', '-A'], repo);
+  git(['commit', '-q', '-m', 'snapshot'], repo);
+  git(['push', '-q', '-u', 'origin', 'main'], repo);
+
+  return { repo, root };
+}
+
+function runScript(repo, extraArgs = ['--mode', 'changeset']) {
+  const outputFile = path.join(repo, 'gh-output.txt');
+  writeFileSync(outputFile, '');
+
+  const result = spawnSync('bun', ['run', SCRIPT_PATH, ...extraArgs], {
+    cwd: repo,
+    env: { ...process.env, GITHUB_OUTPUT: outputFile },
+    encoding: 'utf-8',
+  });
+
+  const outputs = Object.fromEntries(
+    readFileSync(outputFile, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const eq = line.indexOf('=');
+        return [line.slice(0, eq), line.slice(eq + 1)];
+      })
+  );
+
+  return {
+    exitCode: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    outputs,
+  };
+}
+
+describe('version-and-commit', () => {
+  test('does not report already_released when the target tag is missing', () => {
+    // Regression test for
+    // https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/9
+    // Starting at 2.3.0 with a minor changeset should produce 2.4.0,
+    // and the script must not claim 2.4.0 was already released.
+    const { repo, root } = setupRepo({
+      startingVersion: '2.3.0',
+      changesetBump: 'minor',
+    });
+    try {
+      const probe = spawnSync(
+        'git',
+        ['rev-parse', '--verify', '--quiet', 'refs/tags/v2.4.0'],
+        { cwd: repo, encoding: 'utf-8' }
+      );
+      expect(probe.status).not.toBe(0);
+
+      const { exitCode, outputs, stdout, stderr } = runScript(repo);
+
+      expect({ exitCode, stdout, stderr }).toEqual({
+        exitCode: 0,
+        stdout: expect.any(String),
+        stderr: expect.any(String),
+      });
+      expect(outputs.already_released).not.toBe('true');
+      expect(outputs.new_version).toBe('2.4.0');
+      expect(outputs.version_committed).toBe('true');
+
+      const csproj = readFileSync(
+        path.join(repo, 'src', 'MyPackage', 'MyPackage.csproj'),
+        'utf-8'
+      );
+      expect(csproj).toContain('<Version>2.4.0</Version>');
+
+      const log = execFileSync('git', ['log', '--oneline'], {
+        cwd: repo,
+        encoding: 'utf-8',
+      });
+      expect(log).toContain('chore: release v2.4.0');
+
+      const tagListing = execFileSync('git', ['tag', '-l', 'v2.4.0'], {
+        cwd: repo,
+        encoding: 'utf-8',
+      }).trim();
+      expect(tagListing).toBe('v2.4.0');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('reports already_released when the target tag does exist', () => {
+    const { repo, root } = setupRepo({
+      startingVersion: '2.3.0',
+      changesetBump: 'minor',
+    });
+    try {
+      git(['tag', 'v2.4.0'], repo);
+
+      const { exitCode, outputs } = runScript(repo);
+
+      expect(exitCode).toBe(0);
+      expect(outputs.already_released).toBe('true');
+      expect(outputs.new_version).toBe('2.4.0');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #9

## Summary

`scripts/version-and-commit.mjs` could print `already_released=true` for a version whose git tag did not actually exist, skipping the version bump, changelog update, release commit, and tag.

## Root cause

`exec(command, true)` caught command failures and returned an empty string. `checkTagExists()` wrapped a silent command in `try/catch`, but the catch block was never reached because `exec` swallowed the nonzero exit code. As a side effect, the `git diff --cached --quiet` probe had the same issue: staged changes were treated as no changes.

## Fix

- `scripts/version-and-commit.mjs`: drop the silent error-swallowing branch in `exec`, so callers' `try/catch` blocks see real failures.
- `scripts/version-and-commit.mjs`: verify the exact `refs/tags/v<version>` ref in `checkTagExists`.

```diff
 function exec(command, silent = false) {
-  try {
-    return execSync(command, { encoding: 'utf-8', stdio: silent ? 'pipe' : 'inherit' });
-  } catch (error) {
-    if (silent) return '';
-    throw error;
-  }
+  return execSync(command, {
+    encoding: 'utf-8',
+    stdio: silent ? 'pipe' : 'inherit',
+  });
 }

 function checkTagExists(version) {
   try {
-    exec(`git rev-parse v${version}`, true);
+    exec(`git rev-parse --verify --quiet refs/tags/v${version}`, true);
     return true;
   } catch {
     return false;
   }
 }
```

## Reproducer

`experiments/reproduce-bug.sh` initializes a temp repo at `2.3.0`, adds a `minor` changeset, runs the script, and asserts that the v2.4.0 commit and tag are produced.

- Before fix: script printed `already_released=true` / `new_version=2.4.0` and exited; no commit or tag created.
- After fix: csproj bumped to `2.4.0`, CHANGELOG updated, release commit created, `v2.4.0` tag created.

## Regression test

`scripts/version-and-commit.test.mjs` adds two `bun:test` cases (picked up by the existing `bun test scripts/*.test.mjs` CI step):

1. `does not report already_released when the target tag is missing` — fails on the pre-fix code, passes after the fix.
2. `reports already_released when the target tag does exist` — sanity check for the positive case.

## Test plan

- [x] `bun test scripts/version-and-commit.test.mjs` (2 pass)
- [x] `bun test` (all 11 pass)
- [x] `bash experiments/reproduce-bug.sh` exits 0 with the v2.4.0 tag and release commit created