### PR TITLE
fix: wait for NuGet indexing before creating release

### DIFF
--- a/.changeset/wait-for-nuget-indexing.md
+++ b/.changeset/wait-for-nuget-indexing.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Wait longer for NuGet indexing before creating the GitHub release. The previous inline verification used a 0/5/10/20/30/60 second retry schedule that gave up after about 125 seconds, well inside the normal NuGet indexing window (up to 15 minutes per https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package#package-validation-and-indexing). The release workflow now uses a tested `scripts/wait-for-nuget.mjs` helper that polls the flat-container nuspec endpoint 8 times with a 120-second interval, applied to both the automatic `release` job and the manual `instant-release` job. See issue #13 and the matching link-cli reproducer at https://github.com/link-foundation/link-cli/issues/86.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,9 +314,7 @@ jobs:
           if [ -z "$PACKAGE_ID" ]; then
             PACKAGE_ID="MyPackage"
           fi
-          PACKAGE_ID_LOWER=$(echo "$PACKAGE_ID" | tr '[:upper:]' '[:lower:]')
           echo "id=$PACKAGE_ID" >> "$GITHUB_OUTPUT"
-          echo "flat_container_id=$PACKAGE_ID_LOWER" >> "$GITHUB_OUTPUT"
 
       - name: Validate NuGet API key
         # Upfront validation surfaces an expired/invalid NUGET_API_KEY before
@@ -353,7 +351,11 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Verify package on NuGet
+      - name: Wait for NuGet indexing
+        # NuGet's flat-container API can take up to 15 minutes to reflect a
+        # newly pushed package (see issue #13). Poll it via the tested helper
+        # before creating the GitHub release so users can `dotnet add package`
+        # the version mentioned in the release notes.
         if: >-
           steps.nuget_publish.outputs.published == 'true' && (
           steps.version.outputs.version_committed == 'true' ||
@@ -361,22 +363,9 @@ jobs:
           (steps.check_release.outputs.should_release == 'true' &&
            steps.check_release.outputs.skip_bump == 'true'))
         run: |
-          PACKAGE_ID="${{ steps.package.outputs.id }}"
-          PACKAGE_ID_LOWER="${{ steps.package.outputs.flat_container_id }}"
-          VERSION="${{ steps.release_version.outputs.version }}"
-          for DELAY in 0 5 10 20 30 60; do
-            if [ "$DELAY" != "0" ]; then
-              sleep "$DELAY"
-            fi
-            STATUS=$(curl -sS -o /dev/null -w '%{http_code}' "https://api.nuget.org/v3-flatcontainer/${PACKAGE_ID_LOWER}/${VERSION}/${PACKAGE_ID_LOWER}.nuspec" || true)
-            echo "NuGet status for ${PACKAGE_ID}@${VERSION}: ${STATUS}"
-            if [ "$STATUS" = "200" ]; then
-              echo "Verified ${PACKAGE_ID}@${VERSION} is available on NuGet"
-              exit 0
-            fi
-          done
-          echo "::error title=NuGet verification failed::${PACKAGE_ID}@${VERSION} was not available from NuGet after publish."
-          exit 1
+          bun run scripts/wait-for-nuget.mjs \
+            --package-id "${{ steps.package.outputs.id }}" \
+            --release-version "${{ steps.release_version.outputs.version }}"
 
       - name: Create GitHub Release
         if: >-
@@ -451,9 +440,7 @@ jobs:
           if [ -z "$PACKAGE_ID" ]; then
             PACKAGE_ID="MyPackage"
           fi
-          PACKAGE_ID_LOWER=$(echo "$PACKAGE_ID" | tr '[:upper:]' '[:lower:]')
           echo "id=$PACKAGE_ID" >> "$GITHUB_OUTPUT"
-          echo "flat_container_id=$PACKAGE_ID_LOWER" >> "$GITHUB_OUTPUT"
 
       - name: Validate NuGet API key
         if: >-
@@ -484,28 +471,19 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Verify package on NuGet
+      - name: Wait for NuGet indexing
+        # NuGet's flat-container API can take up to 15 minutes to reflect a
+        # newly pushed package (see issue #13). Poll it via the tested helper
+        # before creating the GitHub release so users can `dotnet add package`
+        # the version mentioned in the release notes.
         if: >-
           steps.nuget_publish.outputs.published == 'true' && (
           steps.version.outputs.version_committed == 'true' ||
           steps.version.outputs.already_released == 'true')
         run: |
-          PACKAGE_ID="${{ steps.package.outputs.id }}"
-          PACKAGE_ID_LOWER="${{ steps.package.outputs.flat_container_id }}"
-          VERSION="${{ steps.version.outputs.new_version }}"
-          for DELAY in 0 5 10 20 30 60; do
-            if [ "$DELAY" != "0" ]; then
-              sleep "$DELAY"
-            fi
-            STATUS=$(curl -sS -o /dev/null -w '%{http_code}' "https://api.nuget.org/v3-flatcontainer/${PACKAGE_ID_LOWER}/${VERSION}/${PACKAGE_ID_LOWER}.nuspec" || true)
-            echo "NuGet status for ${PACKAGE_ID}@${VERSION}: ${STATUS}"
-            if [ "$STATUS" = "200" ]; then
-              echo "Verified ${PACKAGE_ID}@${VERSION} is available on NuGet"
-              exit 0
-            fi
-          done
-          echo "::error title=NuGet verification failed::${PACKAGE_ID}@${VERSION} was not available from NuGet after publish."
-          exit 1
+          bun run scripts/wait-for-nuget.mjs \
+            --package-id "${{ steps.package.outputs.id }}" \
+            --release-version "${{ steps.version.outputs.new_version }}"
 
       - name: Create GitHub Release
         if: >-

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-12T20:41:46.333Z for PR creation at branch issue-11-1e642b005557 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/11
-# Updated: 2026-05-12T21:49:40.108Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-12T20:41:46.333Z for PR creation at branch issue-11-1e642b005557 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/11
+# Updated: 2026-05-12T21:49:40.108Z

--- a/scripts/wait-for-nuget.mjs
+++ b/scripts/wait-for-nuget.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+/**
+ * Wait for a NuGet package version to become available from the flat-container API.
+ *
+ * NuGet package validation and indexing usually finish within 15 minutes. The
+ * release workflow uses this script after `dotnet nuget push` so GitHub releases
+ * are created only after the package can be restored by users.
+ *
+ * Background: see issue #13. The previous inline verification used a
+ * 0/5/10/20/30/60 second retry schedule that gave up after ~125 seconds, well
+ * inside the normal NuGet indexing window documented at
+ * https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package#package-validation-and-indexing.
+ *
+ * Usage:
+ *   node scripts/wait-for-nuget.mjs --package-id <id> --release-version <version>
+ *
+ * Optional arguments:
+ *   --max-attempts <count>       Defaults to 8.
+ *   --sleep-seconds <count>      Defaults to 120.
+ *   --flat-container-url <url>   Defaults to https://api.nuget.org/v3-flatcontainer.
+ *
+ * Environment variable overrides (useful for tests):
+ *   - NUGET_FLAT_CONTAINER_URL or NUGET_INDEX_URL
+ *   - NUGET_WAIT_MAX_ATTEMPTS or MAX_ATTEMPTS
+ *   - NUGET_WAIT_SLEEP_SECONDS or SLEEP_SECONDS
+ *   - PACKAGE_ID, RELEASE_VERSION (or VERSION)
+ *
+ * Outputs (written to GITHUB_OUTPUT):
+ *   - nuget_available: 'true' when the package version is visible.
+ */
+
+import { appendFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_FLAT_CONTAINER_URL = 'https://api.nuget.org/v3-flatcontainer';
+export const DEFAULT_MAX_ATTEMPTS = 8;
+export const DEFAULT_SLEEP_SECONDS = 120;
+
+function readCliOptions(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+
+    const inlineValueIndex = arg.indexOf('=');
+    if (inlineValueIndex !== -1) {
+      options[arg.slice(2, inlineValueIndex)] = arg.slice(inlineValueIndex + 1);
+      continue;
+    }
+
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    options[arg.slice(2)] = value;
+    index++;
+  }
+
+  return options;
+}
+
+function parsePositiveInteger(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${optionName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function parseArgs(argv, env = process.env) {
+  const cliOptions = readCliOptions(argv);
+
+  return {
+    flatContainerUrl:
+      cliOptions['flat-container-url'] ||
+      env.NUGET_FLAT_CONTAINER_URL ||
+      env.NUGET_INDEX_URL ||
+      DEFAULT_FLAT_CONTAINER_URL,
+    maxAttempts: parsePositiveInteger(
+      cliOptions['max-attempts'] ||
+        env.NUGET_WAIT_MAX_ATTEMPTS ||
+        env.MAX_ATTEMPTS ||
+        String(DEFAULT_MAX_ATTEMPTS),
+      '--max-attempts'
+    ),
+    packageId: cliOptions['package-id'] || env.PACKAGE_ID || '',
+    releaseVersion:
+      cliOptions['release-version'] ||
+      cliOptions.version ||
+      env.RELEASE_VERSION ||
+      env.VERSION ||
+      '',
+    sleepSeconds: parsePositiveInteger(
+      cliOptions['sleep-seconds'] ||
+        env.NUGET_WAIT_SLEEP_SECONDS ||
+        env.SLEEP_SECONDS ||
+        String(DEFAULT_SLEEP_SECONDS),
+      '--sleep-seconds'
+    ),
+  };
+}
+
+export function createNugetNuspecUrl({
+  flatContainerUrl = DEFAULT_FLAT_CONTAINER_URL,
+  packageId,
+  version,
+}) {
+  const baseUrl = flatContainerUrl.replace(/\/+$/, '');
+  const lowerPackageId = packageId.toLowerCase();
+  const lowerVersion = version.toLowerCase();
+  return `${baseUrl}/${lowerPackageId}/${lowerVersion}/${lowerPackageId}.nuspec`;
+}
+
+export async function checkNugetPackageVersion({
+  fetchImpl = fetch,
+  flatContainerUrl = DEFAULT_FLAT_CONTAINER_URL,
+  packageId,
+  version,
+}) {
+  const url = createNugetNuspecUrl({ flatContainerUrl, packageId, version });
+
+  try {
+    const response = await fetchImpl(url, { method: 'HEAD' });
+    return {
+      available: response.status === 200,
+      status: response.status,
+      url,
+    };
+  } catch (error) {
+    return {
+      available: false,
+      error: error.message,
+      status: 'network-error',
+      url,
+    };
+  }
+}
+
+function sleep(seconds) {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, seconds * 1000);
+  });
+}
+
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${name}=${value}\n`);
+  }
+  console.log(`Output: ${name}=${value}`);
+}
+
+export async function waitForNugetPackage({
+  checkAvailability = checkNugetPackageVersion,
+  flatContainerUrl = DEFAULT_FLAT_CONTAINER_URL,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  packageId,
+  sleepFn = sleep,
+  sleepSeconds = DEFAULT_SLEEP_SECONDS,
+  stdout = console.log,
+  version,
+}) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await checkAvailability({
+      flatContainerUrl,
+      packageId,
+      version,
+    });
+
+    stdout(
+      `NuGet availability for ${packageId}@${version}: ${result.status} ` +
+        `(attempt ${attempt}/${maxAttempts})`
+    );
+
+    if (result.available) {
+      return true;
+    }
+
+    if (result.error) {
+      stdout(`NuGet availability check warning: ${result.error}`);
+    }
+
+    if (attempt < maxAttempts) {
+      stdout(`Waiting ${sleepSeconds}s before the next NuGet availability check`);
+      await sleepFn(sleepSeconds);
+    }
+  }
+
+  return false;
+}
+
+export async function main({
+  argv = process.argv.slice(2),
+  env = process.env,
+  stderr = console.error,
+  stdout = console.log,
+} = {}) {
+  try {
+    const config = parseArgs(argv, env);
+    if (!config.packageId || !config.releaseVersion) {
+      stderr(
+        'Error: --package-id and --release-version are required for NuGet availability checks'
+      );
+      return 1;
+    }
+
+    stdout(
+      `Waiting for ${config.packageId}@${config.releaseVersion} on NuGet ` +
+        `(${config.maxAttempts} attempts, ${config.sleepSeconds}s interval)`
+    );
+
+    const available = await waitForNugetPackage({
+      flatContainerUrl: config.flatContainerUrl,
+      maxAttempts: config.maxAttempts,
+      packageId: config.packageId,
+      sleepSeconds: config.sleepSeconds,
+      stdout,
+      version: config.releaseVersion,
+    });
+
+    setOutput('nuget_available', available ? 'true' : 'false');
+
+    if (!available) {
+      stderr(
+        `${config.packageId}@${config.releaseVersion} did not become available on NuGet`
+      );
+      return 1;
+    }
+
+    stdout(`${config.packageId}@${config.releaseVersion} is available on NuGet`);
+    return 0;
+  } catch (error) {
+    stderr(`Error: ${error.message}`);
+    return 1;
+  }
+}
+
+const invokedDirectly = process.argv[1]
+  && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (invokedDirectly) {
+  process.exitCode = await main();
+}

--- a/scripts/wait-for-nuget.test.mjs
+++ b/scripts/wait-for-nuget.test.mjs
@@ -1,0 +1,357 @@
+import { describe, expect, test } from 'bun:test';
+import { createServer } from 'node:http';
+
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_SLEEP_SECONDS,
+  checkNugetPackageVersion,
+  createNugetNuspecUrl,
+  parseArgs,
+  waitForNugetPackage,
+} from './wait-for-nuget.mjs';
+
+/**
+ * Start a 127.0.0.1 mock that serves the NuGet flat-container nuspec endpoint
+ * `wait-for-nuget.mjs` polls. The script honours `--flat-container-url` (and
+ * `NUGET_FLAT_CONTAINER_URL` / `NUGET_INDEX_URL`) overrides so we can point the
+ * probe at the mock without making real HTTP requests.
+ *
+ * @param {{ statuses: number[] }} options Sequence of HTTP statuses to serve in
+ *   order. The last entry is reused once exhausted.
+ */
+function startNugetMock({ statuses }) {
+  const sockets = new Set();
+  const served = [];
+  let index = 0;
+  const server = createServer((req, res) => {
+    res.setHeader('connection', 'close');
+    const status = statuses[Math.min(index, statuses.length - 1)];
+    index += 1;
+    served.push({ url: req.url, method: req.method, status });
+    res.writeHead(status).end();
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        flatContainerUrl: `http://127.0.0.1:${port}`,
+        served,
+        close: () =>
+          new Promise((r) => {
+            for (const socket of sockets) {
+              socket.destroy();
+            }
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+describe('wait-for-nuget parseArgs()', () => {
+  test('defaults to two-minute checks across the NuGet indexing window', () => {
+    const config = parseArgs(
+      ['--package-id', 'MyPackage', '--release-version', '2.4.0'],
+      {}
+    );
+
+    expect(config.packageId).toBe('MyPackage');
+    expect(config.releaseVersion).toBe('2.4.0');
+    expect(config.maxAttempts).toBe(DEFAULT_MAX_ATTEMPTS);
+    expect(config.sleepSeconds).toBe(DEFAULT_SLEEP_SECONDS);
+    expect(DEFAULT_MAX_ATTEMPTS).toBe(8);
+    expect(DEFAULT_SLEEP_SECONDS).toBe(120);
+  });
+
+  test('accepts --version as an alias for --release-version', () => {
+    const config = parseArgs(
+      ['--package-id', 'MyPackage', '--version', '0.2.1'],
+      {}
+    );
+
+    expect(config.releaseVersion).toBe('0.2.1');
+  });
+
+  test('honours CLI flags for max-attempts, sleep-seconds and flat-container-url', () => {
+    const config = parseArgs(
+      [
+        '--package-id',
+        'MyPackage',
+        '--release-version',
+        '1.0.0',
+        '--max-attempts',
+        '3',
+        '--sleep-seconds',
+        '5',
+        '--flat-container-url',
+        'http://127.0.0.1:9999',
+      ],
+      {}
+    );
+
+    expect(config.maxAttempts).toBe(3);
+    expect(config.sleepSeconds).toBe(5);
+    expect(config.flatContainerUrl).toBe('http://127.0.0.1:9999');
+  });
+
+  test('reads overrides from environment variables', () => {
+    const config = parseArgs([], {
+      PACKAGE_ID: 'MyPackage',
+      RELEASE_VERSION: '1.2.3',
+      NUGET_WAIT_MAX_ATTEMPTS: '4',
+      NUGET_WAIT_SLEEP_SECONDS: '7',
+      NUGET_FLAT_CONTAINER_URL: 'http://mock/flat',
+    });
+
+    expect(config.packageId).toBe('MyPackage');
+    expect(config.releaseVersion).toBe('1.2.3');
+    expect(config.maxAttempts).toBe(4);
+    expect(config.sleepSeconds).toBe(7);
+    expect(config.flatContainerUrl).toBe('http://mock/flat');
+  });
+
+  test('inline --flag=value form is supported', () => {
+    const config = parseArgs(
+      ['--package-id=MyPackage', '--release-version=2.0.0', '--max-attempts=2'],
+      {}
+    );
+
+    expect(config.packageId).toBe('MyPackage');
+    expect(config.releaseVersion).toBe('2.0.0');
+    expect(config.maxAttempts).toBe(2);
+  });
+
+  test('rejects non-positive integers for --max-attempts', () => {
+    expect(() =>
+      parseArgs(
+        ['--package-id', 'p', '--release-version', '1.0.0', '--max-attempts', '0'],
+        {}
+      )
+    ).toThrow(/--max-attempts must be a positive integer/);
+  });
+
+  test('rejects non-positive integers for --sleep-seconds', () => {
+    expect(() =>
+      parseArgs(
+        ['--package-id', 'p', '--release-version', '1.0.0', '--sleep-seconds', '-1'],
+        {}
+      )
+    ).toThrow(/--sleep-seconds must be a positive integer/);
+  });
+
+  test('throws when a flag is missing its value', () => {
+    expect(() => parseArgs(['--package-id'], {})).toThrow(/Missing value for --package-id/);
+  });
+});
+
+describe('wait-for-nuget createNugetNuspecUrl()', () => {
+  test('builds the flat-container nuspec URL with lowercased id and version', () => {
+    expect(
+      createNugetNuspecUrl({
+        flatContainerUrl: 'https://api.nuget.org/v3-flatcontainer/',
+        packageId: 'MyPackage',
+        version: '2.4.0',
+      })
+    ).toBe('https://api.nuget.org/v3-flatcontainer/mypackage/2.4.0/mypackage.nuspec');
+  });
+
+  test('lowercases mixed-case versions (e.g. semver pre-release tags)', () => {
+    expect(
+      createNugetNuspecUrl({
+        flatContainerUrl: 'https://api.nuget.org/v3-flatcontainer',
+        packageId: 'MyPackage',
+        version: '1.0.0-RC.1',
+      })
+    ).toBe('https://api.nuget.org/v3-flatcontainer/mypackage/1.0.0-rc.1/mypackage.nuspec');
+  });
+
+  test('defaults to the official flat-container URL when not specified', () => {
+    expect(
+      createNugetNuspecUrl({ packageId: 'MyPackage', version: '1.0.0' })
+    ).toBe('https://api.nuget.org/v3-flatcontainer/mypackage/1.0.0/mypackage.nuspec');
+  });
+});
+
+describe('wait-for-nuget waitForNugetPackage()', () => {
+  test('succeeds when indexing takes longer than the old 125-second loop', async () => {
+    let attempts = 0;
+    const sleeps = [];
+
+    const available = await waitForNugetPackage({
+      checkAvailability: async () => {
+        attempts++;
+        return {
+          available: attempts === 8,
+          status: attempts === 8 ? 200 : 404,
+        };
+      },
+      maxAttempts: 8,
+      packageId: 'MyPackage',
+      sleepFn: async (seconds) => {
+        sleeps.push(seconds);
+      },
+      sleepSeconds: 120,
+      stdout: () => {},
+      version: '2.4.0',
+    });
+
+    expect(available).toBe(true);
+    expect(attempts).toBe(8);
+    expect(sleeps).toEqual([120, 120, 120, 120, 120, 120, 120]);
+  });
+
+  test('fails only after exhausting all attempts', async () => {
+    let attempts = 0;
+    const sleeps = [];
+
+    const available = await waitForNugetPackage({
+      checkAvailability: async () => {
+        attempts++;
+        return { available: false, status: 404 };
+      },
+      maxAttempts: 3,
+      packageId: 'MyPackage',
+      sleepFn: async (seconds) => {
+        sleeps.push(seconds);
+      },
+      sleepSeconds: 120,
+      stdout: () => {},
+      version: '2.4.0',
+    });
+
+    expect(available).toBe(false);
+    expect(attempts).toBe(3);
+    expect(sleeps).toEqual([120, 120]);
+  });
+
+  test('returns immediately when the package is already indexed', async () => {
+    let attempts = 0;
+    const sleeps = [];
+
+    const available = await waitForNugetPackage({
+      checkAvailability: async () => {
+        attempts++;
+        return { available: true, status: 200 };
+      },
+      maxAttempts: 8,
+      packageId: 'MyPackage',
+      sleepFn: async (seconds) => {
+        sleeps.push(seconds);
+      },
+      sleepSeconds: 120,
+      stdout: () => {},
+      version: '2.4.0',
+    });
+
+    expect(available).toBe(true);
+    expect(attempts).toBe(1);
+    expect(sleeps).toEqual([]);
+  });
+
+  test('tolerates transient network errors before succeeding', async () => {
+    const statuses = [
+      { available: false, status: 'network-error', error: 'ECONNRESET' },
+      { available: true, status: 200 },
+    ];
+    let attempts = 0;
+    const sleeps = [];
+
+    const available = await waitForNugetPackage({
+      checkAvailability: async () => statuses[attempts++],
+      maxAttempts: 4,
+      packageId: 'MyPackage',
+      sleepFn: async (seconds) => {
+        sleeps.push(seconds);
+      },
+      sleepSeconds: 60,
+      stdout: () => {},
+      version: '1.0.0',
+    });
+
+    expect(available).toBe(true);
+    expect(attempts).toBe(2);
+    expect(sleeps).toEqual([60]);
+  });
+});
+
+describe('wait-for-nuget checkNugetPackageVersion()', () => {
+  test('reports 200 responses as available against a live HTTP endpoint', async () => {
+    const mock = await startNugetMock({ statuses: [200] });
+    try {
+      const result = await checkNugetPackageVersion({
+        flatContainerUrl: mock.flatContainerUrl,
+        packageId: 'MyPackage',
+        version: '1.0.0',
+      });
+      expect(result.available).toBe(true);
+      expect(result.status).toBe(200);
+      expect(result.url).toBe(
+        `${mock.flatContainerUrl}/mypackage/1.0.0/mypackage.nuspec`
+      );
+      expect(mock.served).toHaveLength(1);
+      expect(mock.served[0].method).toBe('HEAD');
+      expect(mock.served[0].url).toBe('/mypackage/1.0.0/mypackage.nuspec');
+    } finally {
+      await mock.close();
+    }
+  });
+
+  test('reports 404 responses as unavailable without throwing', async () => {
+    const mock = await startNugetMock({ statuses: [404] });
+    try {
+      const result = await checkNugetPackageVersion({
+        flatContainerUrl: mock.flatContainerUrl,
+        packageId: 'MyPackage',
+        version: '9.9.9',
+      });
+      expect(result.available).toBe(false);
+      expect(result.status).toBe(404);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  test('treats fetch network errors as a soft failure', async () => {
+    const result = await checkNugetPackageVersion({
+      fetchImpl: async () => {
+        throw new Error('connect ECONNREFUSED');
+      },
+      flatContainerUrl: 'http://127.0.0.1:1',
+      packageId: 'MyPackage',
+      version: '1.0.0',
+    });
+    expect(result.available).toBe(false);
+    expect(result.status).toBe('network-error');
+    expect(result.error).toMatch(/ECONNREFUSED/);
+  });
+
+  test('end-to-end: waits through 404 responses then succeeds when the package appears', async () => {
+    const mock = await startNugetMock({ statuses: [404, 404, 200] });
+    const sleeps = [];
+
+    try {
+      const available = await waitForNugetPackage({
+        flatContainerUrl: mock.flatContainerUrl,
+        maxAttempts: 5,
+        packageId: 'MyPackage',
+        sleepFn: async (seconds) => {
+          sleeps.push(seconds);
+        },
+        sleepSeconds: 1,
+        stdout: () => {},
+        version: '1.0.0',
+      });
+
+      expect(available).toBe(true);
+      expect(mock.served).toHaveLength(3);
+      expect(sleeps).toEqual([1, 1]);
+    } finally {
+      await mock.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #13.

Replaces the inline NuGet verifier that gave up after about 125 seconds (`0/5/10/20/30/60` second retries) with a tested `scripts/wait-for-nuget.mjs` helper. The helper polls the flat-container nuspec endpoint 8 times with a 120-second interval, covering the normal NuGet indexing window of up to 15 minutes (per [NuGet's documentation](https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package#package-validation-and-indexing)).

The new step is applied to both release paths:
- The automatic `release` job (changeset-driven and self-heal re-runs).
- The manual `instant-release` job triggered via `workflow_dispatch`.

The unused `steps.package.outputs.flat_container_id` is removed, since the script lowercases the package id and version internally.

## Root Cause

NuGet accepted `clink@2.4.0` (the original reproducer in link-foundation/link-cli#86), but the package was not yet visible from the flat-container API before the old `0/5/10/20/30/60` second retry schedule finished. The flat-container later returned `200` with `last-modified: Tue, 12 May 2026 21:24:36 GMT` — comfortably inside NuGet's documented 15-minute indexing window, but well after the workflow had already failed. The same C# release template ships in this repo (`Verify package on NuGet` in `release.yml`), so this template inherits the bug. See [link-foundation/link-cli#86](https://github.com/link-foundation/link-cli/issues/86) and the matching fix [link-foundation/link-cli#87](https://github.com/link-foundation/link-cli/pull/87).

## What Changed

- **New** `scripts/wait-for-nuget.mjs` — polls `https://api.nuget.org/v3-flatcontainer/<id>/<version>/<id>.nuspec` 8 times with a 120-second interval (overridable via CLI flags / env vars). Exports `parseArgs`, `createNugetNuspecUrl`, `checkNugetPackageVersion`, and `waitForNugetPackage` for unit tests.
- **New** `scripts/wait-for-nuget.test.mjs` — 19 unit tests using `bun:test` (matching the rest of the suite). Covers default tuning, CLI/env overrides, URL construction with mixed-case ids and pre-release versions, success/exhaustion paths, transient network errors, and an end-to-end test against a localhost HTTP mock that returns `404` twice before `200`.
- **Updated** `.github/workflows/release.yml` — both the `release` and `instant-release` jobs now run `bun run scripts/wait-for-nuget.mjs` before creating the GitHub release. The `Resolve NuGet package id` step no longer emits `flat_container_id` because the script handles lowercasing.
- **New** `.changeset/wait-for-nuget-indexing.md` — patch changeset.

## Test Plan

- [x] `bun test scripts/*.test.mjs` (45 pass, 128 expects, 0 fail)
- [x] `bun test scripts/wait-for-nuget.test.mjs` (19 pass, 50 expects, 0 fail)
- [x] `node --check scripts/wait-for-nuget.mjs`
- [x] `bun run scripts/check-file-size.mjs`
- [x] `bun run scripts/validate-changeset.mjs`
- [x] Smoke-tested the CLI:
  `node scripts/wait-for-nuget.mjs --package-id MyPackage --release-version 0.2.1 --max-attempts 1 --sleep-seconds 1` → reports `404` and exits `1` as expected.
- [ ] CI green on this PR

## References

- Issue: #13
- Upstream reproducer: link-foundation/link-cli#86
- Upstream fix used as reference: link-foundation/link-cli#87
- NuGet indexing window: https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package#package-validation-and-indexing
- NuGet flat-container (package-base-address) resource: https://learn.microsoft.com/en-us/nuget/api/package-base-address-resource