### PR TITLE
Add GitHub Pages docs deployment workflow (parity with JS/Rust templates)

### DIFF
--- a/.changeset/docs-pages-deployment.md
+++ b/.changeset/docs-pages-deployment.md
@@ -1,0 +1,9 @@
+---
+'MyPackage': minor
+---
+
+Add GitHub Pages docs deployment workflow (`.github/workflows/docs.yml`) and a
+minimal DocFX configuration (`docfx.json`, `docs/`). Mirrors the JS and Rust
+templates so projects bootstrapped from this template publish API docs to
+`<org>.github.io/<repo>/` on every push to `main` instead of waiting for the
+first tagged release. Closes #15.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,96 @@
+name: docs
+
+# Build and deploy DocFX API documentation to GitHub Pages.
+#
+# Build runs on every push to main and on PRs that touch docs, sources, or
+# this workflow. The deploy job is gated on `push` to `main` (and manual
+# dispatch) — never on `release: published`, so a fresh repository starts
+# publishing as soon as `main` lands. See issue #15 for the failure mode
+# that gating on releases produces.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'src/**'
+      - 'docfx.json'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'src/**'
+      - 'docfx.json'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install DocFX
+        run: dotnet tool update -g docfx
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build documentation site
+        run: docfx docfx.json -o _site
+
+      - name: List built site (debug)
+        run: |
+          echo "::group::_site tree"
+          find _site -maxdepth 3 -print
+          echo "::endgroup::"
+
+      - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        uses: actions/configure-pages@v6
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+      - name: Print resolved deployment URL (debug)
+        run: |
+          echo "Pages deployed to: ${{ steps.deployment.outputs.page_url }}"

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ package-lock.json
 *.temp
 *.swp
 *.swo
+
+# DocFX build output
+_site/
+docs/api/

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-12T20:41:46.333Z for PR creation at branch issue-11-1e642b005557 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/11
+# Updated: 2026-05-12T22:59:43.691Z

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A comprehensive template for AI-driven C# development with full CI/CD pipeline s
 - **CI/CD pipeline**: GitHub Actions with multi-platform support
 - **Changesets workflow**: Version-safe changelog management (like JavaScript Changesets)
 - **Release automation**: Automatic NuGet publishing and GitHub releases
+- **API documentation**: DocFX build and GitHub Pages deployment on every push to `main`
 
 ## Quick Start
 
@@ -90,7 +91,10 @@ dotnet format --verify-no-changes && dotnet build --configuration Release /warna
 │   └── *.md                    # Individual changesets
 ├── .github/
 │   └── workflows/
+│       ├── docs.yml            # DocFX build + GitHub Pages deployment
 │       └── release.yml         # CI/CD pipeline configuration
+├── docs/                       # DocFX content (conceptual docs, TOC)
+├── docfx.json                  # DocFX project configuration
 ├── examples/
 │   ├── BasicUsage.cs           # Usage example
 │   └── BasicUsage.csproj       # Example project
@@ -184,6 +188,26 @@ The GitHub Actions workflow provides:
 3. **Test matrix**: 3 OS (Ubuntu, macOS, Windows) with .NET 8.0
 4. **Building**: Release build and package validation
 5. **Release**: Automated versioning, NuGet publishing, and GitHub releases
+
+### Documentation Site
+
+This template publishes API documentation to GitHub Pages on every push to `main`.
+
+- Build configuration lives in [`docfx.json`](docfx.json).
+- Conceptual docs live in [`docs/`](docs/).
+- The [`docs.yml`](.github/workflows/docs.yml) workflow builds with DocFX and
+  deploys with the official [`actions/deploy-pages`](https://github.com/actions/deploy-pages)
+  action.
+
+**One-time repository setup**: open **Settings → Pages**, set
+**Source = GitHub Actions**. The next push to `main` publishes the site at
+`https://<org>.github.io/<repo>/`.
+
+The deploy job is intentionally gated on `push` to `main` (and manual
+`workflow_dispatch`) rather than `release: published`. Gating on releases
+prevents the very first deploy until a tag is cut, leaving `<org>.github.io/<repo>/`
+returning 404 — exactly the failure documented in
+[issue #15](https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/15).
 
 ### Release Automation
 

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,44 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "src/MyPackage",
+          "files": ["**/*.csproj"]
+        }
+      ],
+      "dest": "docs/api",
+      "includePrivateMembers": false,
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false,
+      "noRestore": false,
+      "namespaceLayout": "flattened",
+      "memberLayout": "samePage",
+      "allowCompilationErrors": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": ["**/*.{md,yml}"],
+        "src": "docs",
+        "exclude": ["_site/**", "obj/**"]
+      }
+    ],
+    "resource": [
+      {
+        "files": ["images/**"],
+        "src": "docs",
+        "exclude": ["_site/**", "obj/**"]
+      }
+    ],
+    "output": "_site",
+    "globalMetadata": {
+      "_appName": "MyPackage",
+      "_appTitle": "MyPackage API Documentation",
+      "_enableSearch": true,
+      "pdf": false
+    },
+    "template": ["default", "modern"]
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# MyPackage Documentation
+
+Welcome to the MyPackage API documentation site, published from this template's
+GitHub Pages deployment workflow.
+
+## Quick links
+
+- [API reference](xref:MyPackage) — auto-generated from XML doc comments in `src/`.
+- [Project README](https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template#readme)
+- [Contributing guide](https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/blob/main/CONTRIBUTING.md)
+
+## How this site is built
+
+`docfx.json` at the repository root drives a [DocFX](https://dotnet.github.io/docfx/)
+build. The `.github/workflows/docs.yml` workflow runs `docfx docfx.json -o _site`
+on every push to `main` and uploads the result as a GitHub Pages artifact.
+
+To configure Pages for a repository created from this template, set
+**Settings → Pages → Source = GitHub Actions** once. After that, every push to
+`main` republishes the site.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,4 @@
+- name: Home
+  href: index.md
+- name: API
+  href: api/


### PR DESCRIPTION
## Summary

Fixes #15.

Adds a DocFX build + GitHub Pages deploy workflow that brings this template
to parity with the JS and Rust pipeline templates. The deploy job is gated on
`push` to `main` (and manual `workflow_dispatch`), **not** on
`release: published`, so a repository bootstrapped from this template starts
publishing as soon as the first push to `main` lands — instead of leaving
`<org>.github.io/<repo>/` returning 404 until a tag is cut.

## Root cause this fixes

Gating Pages deploy on `release: published` (the pattern that bit
[`relative-meta-logic#163`](https://github.com/link-foundation/relative-meta-logic/issues/163))
means the deploy job never runs until somebody manually cuts a release,
which leaves the site at `has_pages: false`. The new workflow follows the
[JS template's pattern](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/blob/main/.github/workflows/example-app.yml)
and the [Rust template's `deploy-docs` job](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/blob/main/.github/workflows/release.yml):
build on every push and PR; deploy on push to `main`.

## Changes

- **`.github/workflows/docs.yml`** — new workflow. Builds DocFX on PRs and
  pushes that touch `docs/**`, `src/**`, `docfx.json`, or the workflow
  itself. Deploys to GitHub Pages on `push` to `main` and on
  `workflow_dispatch` using `actions/configure-pages@v6`,
  `actions/upload-pages-artifact@v5`, and `actions/deploy-pages@v5`.
- **`docfx.json`** — minimal DocFX project pointing at `src/MyPackage`.
- **`docs/index.md`**, **`docs/toc.yml`** — landing page and table of
  contents. Conceptual docs go here; API reference is auto-generated into
  `docs/api/` (gitignored).
- **`.gitignore`** — ignore generated `_site/` and `docs/api/` output.
- **`README.md`** — new \"Documentation Site\" section documenting the
  one-time `Settings → Pages → Source = GitHub Actions` setup and the
  rationale for the chosen trigger gate.
- **`.changeset/docs-pages-deployment.md`** — `minor` changeset.

## Reproducible verification

DocFX builds clean locally with no warnings:

```bash
dotnet tool update -g docfx
docfx docfx.json -o _site
# Build succeeded.
#     0 warning(s)
#     0 error(s)
ls _site/api
# MyPackage.Calculator.html  MyPackage.PackageInfo.html  MyPackage.html  toc.html  toc.json
```

For downstream repositories bootstrapped from this template:

1. Settings → Pages → Source = **GitHub Actions** (one-time, cannot be
   automated from a workflow).
2. Push to `main`.
3. `https://<org>.github.io/<repo>/` serves the rendered site; the
   workflow log prints the resolved deployment URL in its final debug
   step.

## Test plan

- [x] `dotnet format --verify-no-changes`
- [x] `dotnet build --configuration Release /warnaserror`
- [x] `bun test scripts/*.test.mjs`
- [x] `bun run scripts/check-file-size.mjs`
- [x] `bun run scripts/validate-changeset.mjs`
- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))\"` (workflow YAML parses)
- [x] DocFX builds the site locally with 0 warnings, 0 errors.
- [ ] CI passes on this PR.

---
*Generated by AI issue solver — see commit history for the change.*