### PR TITLE
docs: track preview-regeneration parity

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-12T20:41:46.333Z for PR creation at branch issue-11-1e642b005557 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/11
 # Updated: 2026-05-12T22:59:43.691Z
+# Updated: 2026-05-15T07:40:29.775Z

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ GitHub Pages deployment workflow.
 ## Quick links
 
 - [API reference](xref:MyPackage) — auto-generated from XML doc comments in `src/`.
+- [Roadmap](roadmap/preview-regeneration.md) — deferred work tracked in-repo.
 - [Project README](https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template#readme)
 - [Contributing guide](https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/blob/main/CONTRIBUTING.md)
 

--- a/docs/roadmap/preview-regeneration.md
+++ b/docs/roadmap/preview-regeneration.md
@@ -1,0 +1,67 @@
+# Preview-regeneration parity (deferred)
+
+> **Status:** placeholder — waiting on an example-app surface to land in this
+> template before the recipe can be ported.
+
+This template is one of four `link-foundation` AI-driven development pipeline
+templates auditing parity with the [`browser-commander`][bc] +
+[Playwright][pw] preview-regeneration pattern that originated in
+[`konard/vk-bot-desktop`][vk]. The primary upstream tracker is
+[link-foundation/js-ai-driven-development-pipeline-template#62][js62]; the
+mirror for this repository is [issue #17][cs17].
+
+## Why it is deferred here
+
+The pattern auto-regenerates README, GitHub Pages, and `og:image` previews
+from a real browser screenshot of an example app. **This template does not
+yet ship an example-app surface** — the only runnable artifact is
+`examples/BasicUsage`, a console app with no rendered output. Until a web
+surface exists (DocFX site sample, Blazor demo, or similar), there is no
+viewport to capture, so the recipe stays parked here.
+
+## When to port
+
+Port the recipe the next time **any** of the following lands in this repo:
+
+- A Blazor / WASM / Razor Pages example app under `examples/`.
+- A custom DocFX landing page with a hero image worth keeping in sync.
+- An `og:image` or social preview asset committed to the repo.
+
+## Recipe to port
+
+Pull these building blocks from the upstream implementation
+([`scripts/update-preview-images.mjs`][script], [`preview-regen` job][job]):
+
+- Static HTTP server over the built site/app (no devserver, no Electron).
+- `browser.newContext({ locale })` to drive the locale axis without UI toggles.
+- `commander.emulateMedia({ colorScheme })` + `localStorage` to drive theme.
+- `commander.page.screenshot()` — `browser-commander@0.8`+ exposes the raw
+  Playwright page; there is no native screenshot method as of `0.10.1`.
+- `git status --porcelain` drift detection + `git commit -m "... [skip ci]"`
+  push-back so the loop is self-healing.
+- `PREVIEW_VERBOSE=1` to dump DOM probes (`data-theme`, `lang`, `h1`) for
+  CI-only diagnostics.
+
+The integration point in this repo will be a new job in
+`.github/workflows/docs.yml` (next to the DocFX deploy) or a sibling
+`example-app.yml` once one exists. Run on push to `main`, on release tag
+pushes, and on `workflow_dispatch`. Surface drift either as an auto-commit
+back to `main` (push events) or a workflow artifact (pull request events).
+
+## Related
+
+- [konard/vk-bot-desktop#51][vk51] — original issue
+- [konard/vk-bot-desktop#52][vk52] — implementation PR
+- [link-foundation/js-ai-driven-development-pipeline-template#62][js62] — primary upstream tracker
+- [Per-template parity survey][survey]
+
+[bc]: https://www.npmjs.com/package/browser-commander
+[pw]: https://playwright.dev/
+[vk]: https://github.com/konard/vk-bot-desktop
+[vk51]: https://github.com/konard/vk-bot-desktop/issues/51
+[vk52]: https://github.com/konard/vk-bot-desktop/pull/52
+[js62]: https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/62
+[cs17]: https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/17
+[script]: https://github.com/konard/vk-bot-desktop/blob/issue-51-60ec0489f01f/scripts/update-preview-images.mjs
+[job]: https://github.com/konard/vk-bot-desktop/blob/issue-51-60ec0489f01f/.github/workflows/js.yml#L657
+[survey]: https://github.com/konard/vk-bot-desktop/blob/issue-51-60ec0489f01f/docs/case-studies/issue-51/data/templates/survey.md

--- a/docs/roadmap/toc.yml
+++ b/docs/roadmap/toc.yml
@@ -1,0 +1,2 @@
+- name: Preview-regeneration parity
+  href: preview-regeneration.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2,3 +2,5 @@
   href: index.md
 - name: API
   href: api/
+- name: Roadmap
+  href: roadmap/


### PR DESCRIPTION
## Summary

Fixes #17 by landing the **placeholder** half of the suggested action: add an
in-repo tracking note so the browser-commander + Playwright
preview-regeneration recipe is discoverable when the prerequisites land.

Implementation half (`preview-regen` workflow job) stays deferred — see the
"Why it is deferred here" section in the new doc.

## What changed

- `docs/roadmap/preview-regeneration.md` — placeholder tracker with the recipe
  to port, explicit "when to port" triggers, and links to the upstream
  primary host ([js template #62](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/62))
  and the reference implementation ([konard/vk-bot-desktop#52](https://github.com/konard/vk-bot-desktop/pull/52)).
- `docs/roadmap/toc.yml` — DocFX sub-TOC for the roadmap section.
- `docs/toc.yml` — top-level entry so the Roadmap appears in the published site nav.
- `docs/index.md` — Quick-links entry pointing at the new doc.

## Why a doc and not a workflow job

The issue's own "Suggested action" says priority is lower than the JS template
**because there is no example-app surface here yet**. The recipe drives a real
browser screenshot of a rendered app; this template only ships
`examples/BasicUsage`, a console app with no viewport. Adding the workflow
today would have nothing to capture. The doc records the deferred work so it
isn't lost.

## Test plan

- [x] `docfx docfx.json -o _site` — builds clean (0 warnings, 0 errors).
- [x] `dotnet test` — 21/21 passing.
- [x] Built site contains `_site/roadmap/preview-regeneration.html` and the
      Roadmap entry appears in the top-level TOC.
- [x] In-doc links resolve (no DocFX `InvalidFileLink` warnings).

## Follow-ups

When an example-app surface lands (Blazor / WASM / Razor Pages sample, custom
DocFX landing page with a hero image, or a committed `og:image`), port the
[`update-preview-images.mjs`](https://github.com/konard/vk-bot-desktop/blob/issue-51-60ec0489f01f/scripts/update-preview-images.mjs)
+ [`preview-regen` job](https://github.com/konard/vk-bot-desktop/blob/issue-51-60ec0489f01f/.github/workflows/js.yml#L657)
recipe into `.github/workflows/docs.yml` (or a sibling `example-app.yml`).