### PR TITLE
fix: Harden release workflow policy

### DIFF
--- a/.changeset/release-workflow-policy.md
+++ b/.changeset/release-workflow-policy.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Update release workflow reliability policy, job timeouts, and action versions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -43,6 +43,7 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name != 'workflow_dispatch'
     outputs:
       cs-changed: ${{ steps.changes.outputs.cs-changed }}
@@ -54,7 +55,7 @@ jobs:
       workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
       any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -76,10 +77,11 @@ jobs:
   changeset-check:
     name: Changeset Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [detect-changes]
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -109,6 +111,7 @@ jobs:
   lint:
     name: Lint and Format Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [detect-changes]
     if: |
       github.event_name == 'push' ||
@@ -121,7 +124,7 @@ jobs:
       needs.detect-changes.outputs.docs-changed == 'true' ||
       needs.detect-changes.outputs.workflow-changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -152,6 +155,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: [detect-changes, changeset-check]
     # Run if: push event, workflow_dispatch, OR changeset-check succeeded, OR changeset-check was skipped (docs-only PR)
     if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped')
@@ -160,7 +164,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -187,10 +191,11 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [lint, test]
     if: always() && needs.lint.result == 'success' && needs.test.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -207,7 +212,7 @@ jobs:
         run: dotnet pack --no-build --configuration Release --output ./artifacts
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-package
           path: ./artifacts/*.nupkg
@@ -219,11 +224,12 @@ jobs:
     needs: [lint, test, build]
     if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.lint.result == 'success' && needs.test.result == 'success' && needs.build.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -391,11 +397,12 @@ jobs:
     needs: [lint, test, build]
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant' && needs.lint.result == 'success' && needs.test.result == 'success' && needs.build.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -506,11 +513,12 @@ jobs:
     name: Create Changeset PR
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changeset-pr'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -535,7 +543,7 @@ jobs:
           echo "Created changeset: $CHANGESET_FILE"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: add changeset for manual ${{ github.event.inputs.bump_type }} release'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-12T20:41:46.333Z for PR creation at branch issue-11-1e642b005557 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/11
 # Updated: 2026-05-12T22:59:43.691Z
 # Updated: 2026-05-15T07:40:29.775Z
-# Updated: 2026-05-29T20:57:02.923Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T20:41:46.333Z for PR creation at branch issue-11-1e642b005557 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/11
 # Updated: 2026-05-12T22:59:43.691Z
 # Updated: 2026-05-15T07:40:29.775Z
+# Updated: 2026-05-29T20:57:02.923Z

--- a/scripts/release-workflow-policy.test.mjs
+++ b/scripts/release-workflow-policy.test.mjs
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const RELEASE_WORKFLOW = '.github/workflows/release.yml';
+
+const EXPECTED_JOB_TIMEOUTS = new Map([
+  ['detect-changes', 5],
+  ['changeset-check', 10],
+  ['lint', 20],
+  ['test', 30],
+  ['build', 20],
+  ['release', 30],
+  ['instant-release', 30],
+  ['changeset-pr', 10],
+]);
+
+function readWorkflow(filePath) {
+  return readFileSync(filePath, 'utf-8').replaceAll('\r\n', '\n');
+}
+
+function getJobBlocks(workflow) {
+  const lines = workflow.split('\n');
+  const jobsStart = lines.findIndex((line) => line === 'jobs:');
+  if (jobsStart === -1) {
+    return new Map();
+  }
+
+  const blocks = new Map();
+  let currentName = '';
+  let currentLines = [];
+
+  for (const line of lines.slice(jobsStart + 1)) {
+    const match = /^  ([a-zA-Z0-9_-]+):\s*$/.exec(line);
+    if (match) {
+      if (currentName) {
+        blocks.set(currentName, currentLines.join('\n'));
+      }
+      currentName = match[1];
+      currentLines = [line];
+      continue;
+    }
+
+    if (currentName) {
+      currentLines.push(line);
+    }
+  }
+
+  if (currentName) {
+    blocks.set(currentName, currentLines.join('\n'));
+  }
+
+  return blocks;
+}
+
+describe('release workflow policy', () => {
+  test('does not cancel release runs on main when newer pushes arrive', () => {
+    const workflow = readWorkflow(RELEASE_WORKFLOW);
+
+    expect(workflow).toContain(
+      'group: ${{ github.workflow }}-${{ github.ref }}'
+    );
+    expect(workflow).toContain(
+      "cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}"
+    );
+    expect(workflow).not.toContain('cancel-in-progress: true');
+  });
+
+  test('sets explicit timeout-minutes on every job', () => {
+    const workflow = readWorkflow(RELEASE_WORKFLOW);
+    const jobBlocks = getJobBlocks(workflow);
+
+    expect([...jobBlocks.keys()]).toEqual([...EXPECTED_JOB_TIMEOUTS.keys()]);
+
+    for (const [jobName, timeoutMinutes] of EXPECTED_JOB_TIMEOUTS) {
+      expect(jobBlocks.get(jobName)).toContain(
+        `\n    timeout-minutes: ${timeoutMinutes}`
+      );
+    }
+  });
+
+  test('uses the current GitHub Action versions required by the template', () => {
+    const workflow = readWorkflow(RELEASE_WORKFLOW);
+
+    expect(workflow).toContain('uses: actions/checkout@v6');
+    expect(workflow).toContain('uses: actions/upload-artifact@v7');
+    expect(workflow).toContain('uses: peter-evans/create-pull-request@v8');
+    expect(workflow).not.toContain('uses: actions/checkout@v4');
+    expect(workflow).not.toContain('uses: actions/upload-artifact@v4');
+    expect(workflow).not.toContain('uses: peter-evans/create-pull-request@v7');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #19.

- Keep release workflow runs on `main` from being cancelled by newer pushes while still cancelling superseded non-main runs.
- Add explicit `timeout-minutes` values to every `release.yml` job.
- Update the requested action pins: `actions/checkout@v6`, `actions/upload-artifact@v7`, and `peter-evans/create-pull-request@v8`.
- Add a Bun regression test that locks the release workflow policy and a patch changeset for the shipped template change.

## Reproduction

Before the workflow fix, `bun test scripts/release-workflow-policy.test.mjs` failed because `release.yml` still used `cancel-in-progress: true`, had no per-job timeouts, and still referenced the older action versions.

## Tests

- `bun test scripts/release-workflow-policy.test.mjs` (failed before the fix, passes after)
- `bun test scripts/*.test.mjs`
- `GITHUB_BASE_REF=main bun run scripts/validate-changeset.mjs`
- `bun run scripts/check-file-size.mjs`
- `dotnet restore`
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build --no-restore --configuration Release /warnaserror`
- `dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"`
- `git diff --check`

## Notes

Verified the requested action tags exist through the GitHub API before pushing.
