### PR TITLE
fix: Cap generated GitHub release notes

### DIFF
--- a/.changeset/cap-github-release-notes.md
+++ b/.changeset/cap-github-release-notes.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Cap generated GitHub release notes before calling the GitHub Releases API.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T20:41:46.333Z for PR creation at branch issue-11-1e642b005557 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/11
 # Updated: 2026-05-12T22:59:43.691Z
 # Updated: 2026-05-15T07:40:29.775Z
+# Updated: 2026-06-04T17:59:56.352Z

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -18,6 +18,10 @@ import { fileURLToPath } from 'node:url';
 const USAGE =
   'Usage: bun run scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--package-id <id>] [--assets-glob <glob>]';
 
+// Keep comfortably below GitHub's observed 125000-character release body limit.
+export const GITHUB_RELEASE_BODY_MAX_BYTES = 120_000;
+const textEncoder = new globalThis.TextEncoder();
+
 /**
  * Parse CLI arguments.
  * @param {string[]} argv
@@ -167,6 +171,94 @@ export function appendNuGetBadgeIfMissing(releaseNotes, packageId) {
 }
 
 /**
+ * Calculate the UTF-8 byte length for a string.
+ * @param {string} value
+ * @returns {number}
+ */
+function getUtf8ByteLength(value) {
+  return textEncoder.encode(value).byteLength;
+}
+
+/**
+ * Truncate a string without splitting UTF-8 characters.
+ * @param {string} value
+ * @param {number} maxBytes
+ * @returns {string}
+ */
+function truncateToUtf8Bytes(value, maxBytes) {
+  const chunks = [];
+  let usedBytes = 0;
+
+  for (const character of value) {
+    const characterBytes = getUtf8ByteLength(character);
+
+    if (usedBytes + characterBytes > maxBytes) {
+      break;
+    }
+
+    chunks.push(character);
+    usedBytes += characterBytes;
+  }
+
+  return chunks.join('');
+}
+
+/**
+ * Build a link to the changelog at a release tag.
+ * @param {string} repository
+ * @param {string} tag
+ * @returns {string}
+ */
+function buildTaggedChangelogUrl(repository, tag) {
+  return `https://github.com/${repository}/blob/${tag}/CHANGELOG.md`;
+}
+
+/**
+ * Build the note appended when release notes are shortened.
+ * @param {{repository: string, tag: string}} options
+ * @returns {string}
+ */
+function buildTruncatedReleaseNotesNotice({ repository, tag }) {
+  const changelogUrl = buildTaggedChangelogUrl(repository, tag);
+
+  return `Release notes were shortened to fit GitHub's release body limit. See the full tagged CHANGELOG.md: ${changelogUrl}`;
+}
+
+/**
+ * Limit release notes to GitHub's release body budget.
+ * @param {{maxBytes?: number, releaseNotes: string, repository: string, tag: string}} options
+ * @returns {string}
+ */
+export function limitReleaseNotesBytes({
+  maxBytes = GITHUB_RELEASE_BODY_MAX_BYTES,
+  releaseNotes,
+  repository,
+  tag,
+}) {
+  if (getUtf8ByteLength(releaseNotes) <= maxBytes) {
+    return releaseNotes;
+  }
+
+  const suffix = `\n\n...\n\n${buildTruncatedReleaseNotesNotice({
+    repository,
+    tag,
+  })}`;
+  const suffixBytes = getUtf8ByteLength(suffix);
+  const availableBytes = Math.max(0, maxBytes - suffixBytes);
+  const shortenedNotes = truncateToUtf8Bytes(
+    releaseNotes,
+    availableBytes
+  ).trimEnd();
+  const limitedNotes = `${shortenedNotes}${suffix}`;
+
+  if (getUtf8ByteLength(limitedNotes) <= maxBytes) {
+    return limitedNotes;
+  }
+
+  return truncateToUtf8Bytes(limitedNotes, maxBytes);
+}
+
+/**
  * Extract changelog content for a specific version
  * @param {string} changelog
  * @param {string} version
@@ -268,7 +360,7 @@ function walkProjectFiles(dir, candidates, depth = 0) {
 
 /**
  * Build the GitHub release API payload.
- * @param {{changelog: string, language: string, packageId: string, releaseVersion: string, tagPrefix: string}} options
+ * @param {{changelog: string, language: string, packageId: string, releaseVersion: string, repository?: string, tagPrefix: string}} options
  * @returns {string}
  */
 export function buildReleasePayload({
@@ -276,18 +368,20 @@ export function buildReleasePayload({
   language,
   packageId,
   releaseVersion,
+  repository = '',
   tagPrefix,
 }) {
   const semver = normalizeReleaseVersion(releaseVersion);
+  const tag = buildReleaseTag(tagPrefix, semver);
   const releaseNotes = appendNuGetBadgeIfMissing(
     extractReleaseNotes(changelog, semver),
     packageId
   );
 
   return JSON.stringify({
-    tag_name: buildReleaseTag(tagPrefix, semver),
+    tag_name: tag,
     name: buildReleaseTitle(language, semver),
-    body: releaseNotes,
+    body: limitReleaseNotesBytes({ releaseNotes, repository, tag }),
   });
 }
 
@@ -459,6 +553,7 @@ export function main({
       language,
       packageId: resolvedPackageId,
       releaseVersion,
+      repository,
       tagPrefix,
     });
 

--- a/scripts/create-github-release.test.mjs
+++ b/scripts/create-github-release.test.mjs
@@ -15,10 +15,18 @@ import {
   buildReleaseTag,
   buildReleaseTitle,
   findPackageId,
+  GITHUB_RELEASE_BODY_MAX_BYTES,
+  limitReleaseNotesBytes,
   main,
   normalizeReleaseVersion,
   parseArgs,
 } from './create-github-release.mjs';
+
+const textEncoder = new globalThis.TextEncoder();
+
+function getUtf8ByteLength(value) {
+  return textEncoder.encode(value).byteLength;
+}
 
 describe('create-github-release helpers', () => {
   test('parseArgs defaults to the C# release format and accepts package id', () => {
@@ -96,6 +104,44 @@ describe('create-github-release helpers', () => {
         '[![NuGet](https://img.shields.io/nuget/v/MyPackage.svg)]' +
         '(https://www.nuget.org/packages/MyPackage)',
     });
+  });
+
+  test('limits oversized release payload bodies and links the tagged changelog', () => {
+    const hugeNotes = `- ${'a'.repeat(GITHUB_RELEASE_BODY_MAX_BYTES + 10_000)}`;
+    const payload = JSON.parse(
+      buildReleasePayload({
+        changelog: `## [1.2.3] - 2026-06-04\n\n${hugeNotes}\n`,
+        language: 'C#',
+        packageId: 'MyPackage',
+        releaseVersion: '1.2.3',
+        repository: 'owner/repo',
+        tagPrefix: 'csharp_v',
+      })
+    );
+
+    expect(getUtf8ByteLength(payload.body)).toBeLessThanOrEqual(
+      GITHUB_RELEASE_BODY_MAX_BYTES
+    );
+    expect(payload.body.startsWith('- aaa')).toBe(true);
+    expect(payload.body).toContain('Release notes were shortened');
+    expect(payload.body).toContain(
+      'https://github.com/owner/repo/blob/csharp_v1.2.3/CHANGELOG.md'
+    );
+  });
+
+  test('truncates release notes without splitting UTF-8 characters', () => {
+    const limitedNotes = limitReleaseNotesBytes({
+      maxBytes: 600,
+      releaseNotes: '🚀'.repeat(500),
+      repository: 'owner/repo',
+      tag: 'csharp_v1.2.3',
+    });
+
+    expect(getUtf8ByteLength(limitedNotes)).toBeLessThanOrEqual(600);
+    expect(limitedNotes).not.toContain('\uFFFD');
+    expect(limitedNotes).toContain(
+      'https://github.com/owner/repo/blob/csharp_v1.2.3/CHANGELOG.md'
+    );
   });
 
   test('findPackageId reads PackageId from a project file', () => {


### PR DESCRIPTION
## Summary

Fixes #21.

- Cap generated GitHub release bodies to 120,000 UTF-8 bytes before calling the GitHub Releases API.
- Preserve the beginning of oversized changelog entries and append a truncation notice linking to the tagged CHANGELOG.md.
- Add regression coverage for oversized release notes and multi-byte UTF-8 truncation.
- Add a patch changeset for the template release.

## Reproduction

Before the fix, `buildReleasePayload()` passed the extracted changelog entry through unchanged, so a very large `CHANGELOG.md` section could produce an oversized GitHub release `body` and fail release creation with API validation after package publication.

The new regression test feeds an oversized changelog section through `buildReleasePayload()` and verifies the generated release body stays within the guard limit while retaining a link to the full tagged changelog.

## Tests

- `bun test scripts/create-github-release.test.mjs` (failed before implementation, passes after)
- `bun test scripts/*.test.mjs`
- `GITHUB_BASE_REF=main bun run scripts/validate-changeset.mjs`
- `bun run scripts/check-file-size.mjs`
- `dotnet restore`
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build --no-restore --configuration Release /warnaserror`
- `dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"`
- `git diff --check`

## Notes

No UI changes; screenshots are not applicable.
