### PR TITLE
fix(ci): suppress checkout default-branch warning

### DIFF
--- a/.changeset/suppress-git-default-branch-warning.md
+++ b/.changeset/suppress-git-default-branch-warning.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Suppress the Git default-branch warning emitted by release workflow checkout.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
+  GIT_CONFIG_COUNT: '1'
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-03T16:59:38.908Z for PR creation at branch issue-35-dbaf3b300f43 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/35

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-03T16:59:38.908Z for PR creation at branch issue-35-dbaf3b300f43 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/35

--- a/scripts/release-workflow-policy.test.mjs
+++ b/scripts/release-workflow-policy.test.mjs
@@ -80,6 +80,24 @@ function getJobBlocks(workflow) {
   return blocks;
 }
 
+function getTopLevelBlock(workflow, blockName) {
+  const lines = workflow.split('\n');
+  const blockStart = lines.findIndex((line) => line === `${blockName}:`);
+  if (blockStart === -1) {
+    return '';
+  }
+
+  const blockLines = [lines[blockStart]];
+  for (const line of lines.slice(blockStart + 1)) {
+    if (/^\S/.test(line) && line.trim() !== '') {
+      break;
+    }
+    blockLines.push(line);
+  }
+
+  return blockLines.join('\n');
+}
+
 function getStepBlock(jobBlock, stepName) {
   const lines = jobBlock.split('\n');
   const stepStart = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
@@ -175,6 +193,15 @@ describe('release workflow policy', () => {
     expect(workflow).not.toContain('uses: actions/checkout@v4');
     expect(workflow).not.toContain('uses: actions/upload-artifact@v4');
     expect(workflow).not.toContain('uses: peter-evans/create-pull-request@v7');
+  });
+
+  test('configures the default Git branch before checkout runs', () => {
+    const workflow = readWorkflow(RELEASE_WORKFLOW);
+    const workflowEnv = getTopLevelBlock(workflow, 'env');
+
+    expect(workflowEnv).toContain("\n  GIT_CONFIG_COUNT: '1'");
+    expect(workflowEnv).toContain('\n  GIT_CONFIG_KEY_0: init.defaultBranch');
+    expect(workflowEnv).toContain('\n  GIT_CONFIG_VALUE_0: main');
   });
 
   test('gates Codecov uploads on an explicit token', () => {


### PR DESCRIPTION
## Summary

Fixes #35.

- Set workflow-level `GIT_CONFIG_*` variables in `.github/workflows/release.yml` so `actions/checkout@v6` sees `init.defaultBranch=main` before its internal `git init` runs.
- Add a release workflow policy test that asserts the Git config remains in the top-level workflow `env:` block.
- Add a patch changeset for the CI workflow behavior change.

## Reproduction

Added a failing contract test in `scripts/release-workflow-policy.test.mjs`. Before the workflow change, `bun test scripts/release-workflow-policy.test.mjs` failed because the top-level workflow environment did not contain `GIT_CONFIG_COUNT: '1'`.

## Verification

- `bun test scripts/release-workflow-policy.test.mjs`
- `bun test scripts/*.test.mjs`
- `bun run scripts/check-file-size.mjs`
- `dotnet restore`
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build --configuration Release /warnaserror`
- `dotnet test --no-build --configuration Release --verbosity normal`
- `GITHUB_BASE_SHA="$(git rev-parse origin/main)" GITHUB_HEAD_SHA="$(git rev-parse HEAD)" bun run scripts/validate-changeset.mjs`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_SHA="$(git rev-parse origin/main)" GITHUB_HEAD_SHA="$(git rev-parse HEAD)" bun run scripts/detect-code-changes.mjs`
