### PR TITLE
fix(ci): upgrade actions for Node 24 runners

### DIFF
--- a/.changeset/modern-actions.md
+++ b/.changeset/modern-actions.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Upgrade the .NET setup and Codecov workflow actions for Node 24 runners.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
           echo "Detected C# layout: root=$CSHARP_ROOT, multi-language=$MULTI_LANGUAGE"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -269,7 +269,7 @@ jobs:
           echo "Detected C# layout: root=$CSHARP_ROOT, multi-language=$MULTI_LANGUAGE"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -291,7 +291,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -327,7 +327,7 @@ jobs:
           echo "Detected C# layout: root=$CSHARP_ROOT, multi-language=$MULTI_LANGUAGE"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -385,7 +385,7 @@ jobs:
           echo "Detected C# layout: root=$CSHARP_ROOT, multi-language=$MULTI_LANGUAGE"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -614,7 +614,7 @@ jobs:
           echo "Detected C# layout: root=$CSHARP_ROOT, multi-language=$MULTI_LANGUAGE"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-27T04:13:12.176Z for PR creation at branch issue-39-4688e50822b9 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/39

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-27T04:13:12.176Z for PR creation at branch issue-39-4688e50822b9 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/39

--- a/scripts/release-workflow-policy.test.mjs
+++ b/scripts/release-workflow-policy.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
 const RELEASE_WORKFLOW = '.github/workflows/release.yml';
+const DOCS_WORKFLOW = '.github/workflows/docs.yml';
 
 const EXPECTED_JOB_TIMEOUTS = new Map([
   ['detect-changes', 5],
@@ -186,13 +187,20 @@ describe('release workflow policy', () => {
 
   test('uses the current GitHub Action versions required by the template', () => {
     const workflow = readWorkflow(RELEASE_WORKFLOW);
+    const docsWorkflow = readWorkflow(DOCS_WORKFLOW);
 
     expect(workflow).toContain('uses: actions/checkout@v6');
+    expect(workflow).toContain('uses: actions/setup-dotnet@v5');
     expect(workflow).toContain('uses: actions/upload-artifact@v7');
+    expect(workflow).toContain('uses: codecov/codecov-action@v7');
     expect(workflow).toContain('uses: peter-evans/create-pull-request@v8');
     expect(workflow).not.toContain('uses: actions/checkout@v4');
+    expect(workflow).not.toContain('uses: actions/setup-dotnet@v4');
     expect(workflow).not.toContain('uses: actions/upload-artifact@v4');
+    expect(workflow).not.toContain('uses: codecov/codecov-action@v4');
     expect(workflow).not.toContain('uses: peter-evans/create-pull-request@v7');
+    expect(docsWorkflow).toContain('uses: actions/setup-dotnet@v5');
+    expect(docsWorkflow).not.toContain('uses: actions/setup-dotnet@v4');
   });
 
   test('configures the default Git branch before checkout runs', () => {
@@ -217,7 +225,7 @@ describe('release workflow policy', () => {
     expect(uploadStep).toContain(
       "if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''"
     );
-    expect(uploadStep).toContain('uses: codecov/codecov-action@v4');
+    expect(uploadStep).toContain('uses: codecov/codecov-action@v7');
     expect(uploadStep).toContain('token: ${{ env.CODECOV_TOKEN }}');
     expect(uploadStep).toContain('fail_ci_if_error: true');
     expect(uploadStep).not.toContain('fail_ci_if_error: false');


### PR DESCRIPTION
## Summary

- upgrade every `actions/setup-dotnet` use from v4 to v5 in the release and docs workflows
- upgrade `codecov/codecov-action` from v4 to v7
- extend workflow policy tests to require the current majors and reject regressions
- add a patch changeset for template consumers

## Reproduction

Before this change, `bun test scripts/release-workflow-policy.test.mjs` fails the new version policy because the workflows still reference setup-dotnet v4 and Codecov v4.

## Verification

- `bun test scripts/*.test.mjs` — 76 passed
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build --configuration Release /warnaserror` — 0 warnings, 0 errors
- `dotnet test --configuration Release --no-build --verbosity normal` — 21 passed
- `bun run scripts/check-file-size.mjs`

Fixes #39
