### PR TITLE
fix(ci): honor excluded paths on pushes

### DIFF
--- a/.changeset/fix-excluded-change-detection.md
+++ b/.changeset/fix-excluded-change-detection.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Keep excluded-only pull requests and pushes from activating change-gated CI jobs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,6 @@ jobs:
     timeout-minutes: 5
     if: github.event_name != 'workflow_dispatch'
     outputs:
-      cs-changed: ${{ steps.changes.outputs.cs-changed }}
-      csproj-changed: ${{ steps.changes.outputs.csproj-changed }}
-      sln-changed: ${{ steps.changes.outputs.sln-changed }}
-      props-changed: ${{ steps.changes.outputs.props-changed }}
-      mjs-changed: ${{ steps.changes.outputs.mjs-changed }}
-      docs-changed: ${{ steps.changes.outputs.docs-changed }}
-      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
       any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
     steps:
       - uses: actions/checkout@v6
@@ -162,15 +155,8 @@ jobs:
     # always() && !cancelled() lets the OR conditions decide instead.
     if: |
       always() && !cancelled() && (
-        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.cs-changed == 'true' ||
-        needs.detect-changes.outputs.csproj-changed == 'true' ||
-        needs.detect-changes.outputs.sln-changed == 'true' ||
-        needs.detect-changes.outputs.props-changed == 'true' ||
-        needs.detect-changes.outputs.mjs-changed == 'true' ||
-        needs.detect-changes.outputs.docs-changed == 'true' ||
-        needs.detect-changes.outputs.workflow-changed == 'true'
+        needs.detect-changes.outputs.any-code-changed == 'true'
       )
     steps:
       - uses: actions/checkout@v6
@@ -235,12 +221,8 @@ jobs:
     # Run tests only for events or file changes that affect runtime behavior.
     if: |
       always() && !cancelled() && (
-        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.any-code-changed == 'true' ||
-        needs.detect-changes.outputs.cs-changed == 'true' ||
-        needs.detect-changes.outputs.csproj-changed == 'true' ||
-        needs.detect-changes.outputs.workflow-changed == 'true'
+        needs.detect-changes.outputs.any-code-changed == 'true'
       )
     strategy:
       fail-fast: false

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-27T04:18:18.282Z for PR creation at branch issue-40-457fe48f6812 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/40

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-27T04:18:18.282Z for PR creation at branch issue-40-457fe48f6812 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/40

--- a/scripts/detect-code-changes.mjs
+++ b/scripts/detect-code-changes.mjs
@@ -15,6 +15,7 @@
  * - Markdown files (*.md) in any folder
  * - .changeset/ folder (changeset metadata)
  * - docs/ folder (documentation)
+ * - dev/log/ folder (development logs)
  * - experiments/ folder (experimental scripts)
  * - examples/ folder (example scripts)
  *
@@ -27,14 +28,7 @@
  *   - GITHUB_HEAD_SHA: Head commit SHA for PR
  *
  * Outputs (written to GITHUB_OUTPUT):
- *   - cs-changed: 'true' if any .cs files changed
- *   - csproj-changed: 'true' if any .csproj files changed
- *   - sln-changed: 'true' if any .sln files changed
- *   - props-changed: 'true' if any .props files changed (Directory.Build.props etc.)
- *   - mjs-changed: 'true' if any .mjs files changed (scripts)
- *   - docs-changed: 'true' if any .md files changed
- *   - workflow-changed: 'true' if any .github/workflows/ files changed
- *   - any-code-changed: 'true' if any code files changed (excludes docs, changesets, experiments, examples)
+ *   - any-code-changed: 'true' if any code files changed after applying the exclusion policy
  */
 
 import { execSync } from 'child_process';
@@ -124,7 +118,7 @@ function getChangedFiles() {
  * @param {string} filePath - The file path to check
  * @returns {boolean} True if the file should be excluded
  */
-function isExcludedFromCodeChanges(filePath) {
+export function isExcludedFromCodeChanges(filePath) {
   // Exclude markdown files in any folder
   if (filePath.endsWith('.md')) {
     return true;
@@ -134,10 +128,12 @@ function isExcludedFromCodeChanges(filePath) {
   const excludedFolders = [
     '.changeset/',
     'docs/',
+    'dev/log/',
     'experiments/',
     'examples/',
     prefixCsharpRoot('.changeset/'),
     prefixCsharpRoot('docs/'),
+    prefixCsharpRoot('dev/log/'),
     prefixCsharpRoot('experiments/'),
     prefixCsharpRoot('examples/'),
   ];
@@ -149,6 +145,21 @@ function isExcludedFromCodeChanges(filePath) {
   }
 
   return false;
+}
+
+/**
+ * Compute the outputs used by change-gated workflow jobs.
+ * @param {string[]} changedFiles - Changed repository-relative paths
+ * @returns {{ 'any-code-changed': string }} GitHub Actions output values
+ */
+export function detectChangeOutputs(changedFiles) {
+  const includedFiles = changedFiles.filter(
+    (file) => !isExcludedFromCodeChanges(file)
+  );
+  const codePattern = /\.(cs|csproj|sln|props|mjs|json|yml|yaml)$|\.github\/workflows\//;
+  const codeChanged = includedFiles.some((file) => codePattern.test(file));
+
+  return { 'any-code-changed': codeChanged ? 'true' : 'false' };
 }
 
 /**
@@ -167,37 +178,7 @@ function detectChanges() {
   }
   console.log('');
 
-  // Detect .cs file changes (C# source files)
-  const csChanged = changedFiles.some((file) => file.endsWith('.cs'));
-  setOutput('cs-changed', csChanged ? 'true' : 'false');
-
-  // Detect .csproj file changes (project files)
-  const csprojChanged = changedFiles.some((file) => file.endsWith('.csproj'));
-  setOutput('csproj-changed', csprojChanged ? 'true' : 'false');
-
-  // Detect .sln file changes (solution files)
-  const slnChanged = changedFiles.some((file) => file.endsWith('.sln'));
-  setOutput('sln-changed', slnChanged ? 'true' : 'false');
-
-  // Detect .props file changes (Directory.Build.props, etc.)
-  const propsChanged = changedFiles.some((file) => file.endsWith('.props'));
-  setOutput('props-changed', propsChanged ? 'true' : 'false');
-
-  // Detect .mjs file changes (scripts)
-  const mjsChanged = changedFiles.some((file) => file.endsWith('.mjs'));
-  setOutput('mjs-changed', mjsChanged ? 'true' : 'false');
-
-  // Detect documentation changes (any .md file)
-  const docsChanged = changedFiles.some((file) => file.endsWith('.md'));
-  setOutput('docs-changed', docsChanged ? 'true' : 'false');
-
-  // Detect workflow changes
-  const workflowChanged = changedFiles.some((file) =>
-    file.startsWith('.github/workflows/')
-  );
-  setOutput('workflow-changed', workflowChanged ? 'true' : 'false');
-
-  // Detect code changes (excluding docs, changesets, experiments, examples folders, and markdown files)
+  // Apply the exclusion policy before computing every job-gating output.
   const codeChangedFiles = changedFiles.filter(
     (file) => !isExcludedFromCodeChanges(file)
   );
@@ -210,13 +191,13 @@ function detectChanges() {
   }
   console.log('');
 
-  // Check if any code files changed (.cs, .csproj, .sln, .props, .mjs, .json, .yml, .yaml, or workflow files)
-  const codePattern = /\.(cs|csproj|sln|props|mjs|json|yml|yaml)$|\.github\/workflows\//;
-  const codeChanged = codeChangedFiles.some((file) => codePattern.test(file));
-  setOutput('any-code-changed', codeChanged ? 'true' : 'false');
+  const outputs = detectChangeOutputs(changedFiles);
+  setOutput('any-code-changed', outputs['any-code-changed']);
 
   console.log('\nChange detection completed.');
 }
 
 // Run the detection
-detectChanges();
+if (import.meta.main) {
+  detectChanges();
+}

--- a/scripts/detect-code-changes.test.mjs
+++ b/scripts/detect-code-changes.test.mjs
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { detectChangeOutputs } from './detect-code-changes.mjs';
+
+const EXCLUDED_EVENT_MATRIX = [
+  ['pull_request', 'experiments/repro.mjs'],
+  ['push', 'experiments/repro.md'],
+  ['pull_request', 'dev/log/repro.mjs'],
+  ['push', 'dev/log/repro.md'],
+  ['pull_request', 'docs/case-studies/repro.mjs'],
+  ['push', 'docs/case-studies/repro.md'],
+];
+
+describe('code change detection', () => {
+  test.each(EXCLUDED_EVENT_MATRIX)(
+    '%s ignores excluded-only change %s',
+    (_eventName, changedFile) => {
+      expect(detectChangeOutputs([changedFile])).toEqual({
+        'any-code-changed': 'false',
+      });
+    }
+  );
+
+  test.each([
+    'src/MyPackage/Calculator.cs',
+    'scripts/check-file-size.mjs',
+    '.github/workflows/release.yml',
+  ])('detects code change %s', (changedFile) => {
+    expect(detectChangeOutputs([changedFile])).toEqual({
+      'any-code-changed': 'true',
+    });
+  });
+
+  test('detects code when excluded and included files are mixed', () => {
+    expect(
+      detectChangeOutputs([
+        'experiments/repro.mjs',
+        'docs/case-studies/notes.md',
+        'src/MyPackage/Calculator.cs',
+      ])
+    ).toEqual({ 'any-code-changed': 'true' });
+  });
+});

--- a/scripts/release-workflow-policy.test.mjs
+++ b/scripts/release-workflow-policy.test.mjs
@@ -166,22 +166,34 @@ describe('release workflow policy', () => {
     expect(condition).toContain("needs.build.result == 'success'");
   });
 
-  test('test job is gated by change detector outputs, not changeset-check skip state', () => {
+  test('change-gated jobs use detector output for both pull requests and pushes', () => {
     const workflow = readWorkflow(RELEASE_WORKFLOW);
-    const testJob = getJobBlocks(workflow).get('test');
-    const condition = getJobCondition(testJob);
+    const jobBlocks = getJobBlocks(workflow);
 
-    expect(testJob).toContain('needs: [detect-changes]');
-    expect(testJob).not.toContain('needs: [detect-changes, changeset-check]');
-    expect(condition).toContain('always()');
-    expect(condition).toContain('!cancelled()');
-    expect(condition).toContain("github.event_name == 'push'");
-    expect(condition).toContain("github.event_name == 'workflow_dispatch'");
-    expect(condition).toContain("needs.detect-changes.outputs.any-code-changed == 'true'");
-    expect(condition).toContain("needs.detect-changes.outputs.cs-changed == 'true'");
-    expect(condition).toContain("needs.detect-changes.outputs.csproj-changed == 'true'");
-    expect(condition).toContain("needs.detect-changes.outputs.workflow-changed == 'true'");
-    expect(condition).not.toContain('needs.changeset-check.result');
+    for (const jobName of ['lint', 'test']) {
+      const job = jobBlocks.get(jobName);
+      const condition = getJobCondition(job);
+
+      expect(job).toContain('needs: [detect-changes]');
+      expect(condition).toContain('always()');
+      expect(condition).toContain('!cancelled()');
+      expect(condition).toContain("github.event_name == 'workflow_dispatch'");
+      expect(condition).toContain(
+        "needs.detect-changes.outputs.any-code-changed == 'true'"
+      );
+      expect(condition).not.toContain("github.event_name == 'push'");
+      expect(condition).not.toContain('needs.changeset-check.result');
+    }
+  });
+
+  test('publishes only the detector output consumed by job gates', () => {
+    const workflow = readWorkflow(RELEASE_WORKFLOW);
+    const detectJob = getJobBlocks(workflow).get('detect-changes');
+
+    expect(detectJob).toContain(
+      'any-code-changed: ${{ steps.changes.outputs.any-code-changed }}'
+    );
+    expect(detectJob).not.toMatch(/^\s+(cs|csproj|sln|props|mjs|docs|workflow)-changed:/m);
   });
 
   test('uses the current GitHub Action versions required by the template', () => {


### PR DESCRIPTION
## Summary

- apply the ignored-path policy before computing the aggregate CI change signal
- gate lint and test on that signal for both pull requests and direct pushes while preserving manual dispatch behavior
- remove unused extension-specific detector outputs
- add event/path regression coverage for `experiments/`, `dev/log/`, and `docs/case-studies/`

## Reproduction

Before this fix, a direct push containing only an excluded file still ran lint and test because their job conditions accepted every `push` unconditionally. On pull requests, raw extension outputs could likewise activate jobs before ignored paths were filtered.

The new detector and workflow policy tests reproduce both failure modes and verify that included code and mixed changes still activate CI.

## Verification

- `dotnet format --verify-no-changes`
- `dotnet build --configuration Release /warnaserror`
- `bun test scripts/*.test.mjs` (87 passed)
- `bun run scripts/validate-changeset.mjs`
- `bun run scripts/check-file-size.mjs`
- `dotnet test --no-build --configuration Release` (21 passed)

Fixes #40