### PR TITLE
feat(ci): add CodeQL and dependency review

### DIFF
--- a/.changeset/add-security-scanning.md
+++ b/.changeset/add-security-scanning.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Add CodeQL analysis for C# and GitHub Actions workflows, plus pull-request dependency review.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,11 +27,11 @@ jobs:
         language: [csharp, actions]
     steps:
       - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/analyze@v4
 
   dependency-review:
     name: Dependency Review
@@ -43,7 +43,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,49 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: check-${{ github.workflow }}-${{ github.ref }}-codeql-${{ matrix.language }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [csharp, actions]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-09T02:36:49.239Z for PR creation at branch issue-43-4a7cceb84f7b for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/43

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-09T02:36:49.239Z for PR creation at branch issue-43-4a7cceb84f7b for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/43

--- a/scripts/security-workflow-policy.test.mjs
+++ b/scripts/security-workflow-policy.test.mjs
@@ -20,9 +20,9 @@ describe('security workflow policy', () => {
     const workflow = readWorkflow();
 
     expect(workflow).toContain('language: [csharp, actions]');
-    expect(workflow).toContain('uses: github/codeql-action/init@v3');
-    expect(workflow).toContain('uses: github/codeql-action/autobuild@v3');
-    expect(workflow).toContain('uses: github/codeql-action/analyze@v3');
+    expect(workflow).toContain('uses: github/codeql-action/init@v4');
+    expect(workflow).toContain('uses: github/codeql-action/autobuild@v4');
+    expect(workflow).toContain('uses: github/codeql-action/analyze@v4');
     expect(workflow).toContain('security-events: write');
   });
 
@@ -30,7 +30,7 @@ describe('security workflow policy', () => {
     const workflow = readWorkflow();
 
     expect(workflow).toContain("if: github.event_name == 'pull_request'");
-    expect(workflow).toContain('uses: actions/dependency-review-action@v4');
+    expect(workflow).toContain('uses: actions/dependency-review-action@v5');
     expect(workflow).toContain('fail-on-severity: high');
     expect(workflow).toContain('comment-summary-in-pr: on-failure');
     expect(workflow).toContain('pull-requests: write');

--- a/scripts/security-workflow-policy.test.mjs
+++ b/scripts/security-workflow-policy.test.mjs
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const SECURITY_WORKFLOW = '.github/workflows/security.yml';
+
+function readWorkflow() {
+  return readFileSync(SECURITY_WORKFLOW, 'utf-8').replaceAll('\r\n', '\n');
+}
+
+describe('security workflow policy', () => {
+  test('scans pushes, pull requests, and the weekly schedule', () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain("cron: '0 6 * * 1'");
+  });
+
+  test('analyzes C# and GitHub Actions with CodeQL', () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain('language: [csharp, actions]');
+    expect(workflow).toContain('uses: github/codeql-action/init@v3');
+    expect(workflow).toContain('uses: github/codeql-action/autobuild@v3');
+    expect(workflow).toContain('uses: github/codeql-action/analyze@v3');
+    expect(workflow).toContain('security-events: write');
+  });
+
+  test('rejects high-severity dependency changes on pull requests', () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("if: github.event_name == 'pull_request'");
+    expect(workflow).toContain('uses: actions/dependency-review-action@v4');
+    expect(workflow).toContain('fail-on-severity: high');
+    expect(workflow).toContain('comment-summary-in-pr: on-failure');
+    expect(workflow).toContain('pull-requests: write');
+  });
+
+  test('uses current checkout and bounded jobs', () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain('uses: actions/checkout@v6');
+    expect(workflow).toContain('timeout-minutes: 30');
+    expect(workflow).toContain('timeout-minutes: 10');
+    expect(workflow).toContain('cancel-in-progress: true');
+  });
+});


### PR DESCRIPTION
## Summary

- add a dedicated security workflow for pushes to `main`, pull requests, and weekly scheduled scans
- analyze both C# source and GitHub Actions workflows with CodeQL
- reject pull requests that introduce high-severity vulnerable dependencies
- add policy tests that lock down triggers, action versions, permissions, timeouts, and scanner configuration
- add the required patch changeset

## Reproduction

On `main`, `.github/workflows/security.yml` did not exist, so the security workflow policy test failed with `ENOENT`. There were no CodeQL, dependency-review, SBOM, or vulnerability-scanner steps under `.github/`.

## Verification

- `bun test scripts/*.test.mjs` — 91 passed
- `dotnet format --verify-no-changes`
- `dotnet build --configuration Release /warnaserror` — 0 warnings, 0 errors
- `dotnet test --configuration Release --no-build --verbosity normal` — 21 passed
- `bun run scripts/check-file-size.mjs`
- `bun run scripts/validate-changeset.mjs`
- `git diff --check`

Fixes #43
