### PR TITLE
feat(ci): add broken-link validation

### DIFF
--- a/.changeset/add-broken-link-checker.md
+++ b/.changeset/add-broken-link-checker.md
@@ -1,0 +1,5 @@
+---
+'MyPackage': patch
+---
+
+Validate Markdown and HTML links in CI, with Wayback Machine fallback guidance for broken URLs.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,98 @@
+name: Broken Link Checker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+      - '**.html'
+      - '.github/workflows/links.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**.md'
+      - '**.html'
+      - '.github/workflows/links.yml'
+  workflow_dispatch:
+
+# Least-privilege default; jobs escalate individually when needed.
+permissions:
+  contents: read
+
+# Provide Git config to actions/checkout itself; checkout runs git init before
+# any workflow step can configure Git.
+env:
+  GIT_CONFIG_COUNT: '1'
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
+jobs:
+  link-checker:
+    name: Check Links
+    runs-on: ubuntu-latest
+    # Typical run: <1min with lychee cache. 10min prevents slow
+    # external hosts or Wayback Machine probes from hanging the workflow.
+    timeout-minutes: 10
+    concurrency:
+      group: check-${{ github.workflow }}-${{ github.ref }}-link-checker
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check links with lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Check all Markdown and HTML files
+          # Exclude case-studies directory - these are research documents from
+          # external repos with references to files and issues that don't exist
+          # in this repository (similar exclusion pattern as eslint.config.js)
+          args: >-
+            --verbose
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --max-retries 3
+            --timeout 30
+            --exclude-path docs/case-studies
+            './**/*.md'
+            './**/*.html'
+          # Don't fail the workflow immediately - we want to check web archive first
+          fail: false
+          # Output file for broken links report (used by check-web-archive.mjs)
+          output: lychee/out.md
+          # Write a job summary
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check broken links against Web Archive
+        if: steps.lychee.outputs.exit_code != 0
+        id: webarchive
+        run: node scripts/check-web-archive.mjs
+        env:
+          LYCHEE_OUTPUT: lychee/out.md
+
+      - name: Fail if broken links found and no web archive fallback
+        if: steps.lychee.outputs.exit_code != 0 && steps.webarchive.outputs.all_archived != 'true'
+        run: |
+          echo "::error::Broken links were detected with no Web Archive fallback available."
+          echo ""
+          echo "What happened:"
+          echo "  lychee found one or more broken links in the *.md and *.html files of this repository."
+          echo "  The Web Archive (Wayback Machine) check found no archived versions for some of them."
+          echo ""
+          echo "How to fix:"
+          echo "  1. Review the 'Check links with lychee' step above for a full list of broken links."
+          echo "  2. For links marked with a '::notice::' annotation above, a Web Archive version exists."
+          echo "     Replace those broken links with the suggested archive.org URL."
+          echo "  3. For links with no archive version, either:"
+          echo "     a. Find an updated URL that points to the same or equivalent content."
+          echo "     b. Remove the link if the content is no longer relevant."
+          echo "     c. Add the URL to .lycheeignore if it is a known false positive."
+          echo ""
+          echo "Report location: lychee/out.md (available as a workflow artifact if configured)."
+          exit 1

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-09T02:42:43.600Z for PR creation at branch issue-44-f7c8523802e9 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/44

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-09T02:42:43.600Z for PR creation at branch issue-44-f7c8523802e9 for issue https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/44

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+# Lychee ignore patterns - regex patterns for URLs to skip during link checking
+
+# npmjs.com returns 403 to link checkers because of bot protection.
+https://www\.npmjs\.com

--- a/scripts/check-web-archive.mjs
+++ b/scripts/check-web-archive.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+/**
+ * Check broken links against the Wayback Machine (web.archive.org)
+ *
+ * This script reads the lychee link checker output (markdown format),
+ * extracts broken URLs, and checks each one against the Wayback Machine API.
+ * It then outputs a report with:
+ * - Links that have a web archive version (with suggestion to replace)
+ * - Links that have no web archive version (clearly marked as unrecoverable)
+ *
+ * Usage:
+ *   node scripts/check-web-archive.mjs
+ *
+ * Environment variables:
+ *   - LYCHEE_OUTPUT: Path to lychee markdown output file (default: lychee/out.md)
+ *
+ * GitHub Actions outputs:
+ *   - all_archived: 'true' if all broken links have a web archive version
+ *
+ * Exit codes:
+ *   - 0: All broken links have web archive versions (or no broken links)
+ *   - 1: Some broken links have no web archive version
+ */
+
+import { readFileSync, appendFileSync, existsSync } from 'fs';
+
+const WAYBACK_API = 'https://archive.org/wayback/available?url=';
+
+/**
+ * Write output to GitHub Actions output file
+ * @param {string} name - Output name
+ * @param {string} value - Output value
+ */
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${name}=${value}\n`);
+  }
+  console.log(`${name}=${value}`);
+}
+
+/**
+ * Extract broken URLs from lychee markdown output
+ * Lychee markdown format includes lines like:
+ *   * [404] https://example.com/broken-link
+ *   * [ERROR] https://another-broken.com
+ * @param {string} content - The markdown content from lychee
+ * @returns {string[]} Array of broken URLs
+ */
+function extractBrokenUrls(content) {
+  const urls = [];
+
+  // Match lines with error status codes or ERROR markers followed by URLs
+  // Lychee output format: [STATUS_CODE] URL or bullet points with links
+  const urlPattern =
+    /\[(?:4\d\d|5\d\d|ERROR|TIMEOUT|UNKNOWN)\]\s+(https?:\/\/[^\s)]+)/gi;
+  let match;
+
+  while ((match = urlPattern.exec(content)) !== null) {
+    const url = match[1].trim();
+    if (url && !urls.includes(url)) {
+      urls.push(url);
+    }
+  }
+
+  // Also match plain URL lines in broken sections
+  // Lychee sometimes outputs: `[ERROR] url | description`
+  const linePattern = /^\s*(?:\*|-)\s+.*?(https?:\/\/[^\s|)>\]]+)/gm;
+  let lineMatch;
+
+  while ((lineMatch = linePattern.exec(content)) !== null) {
+    const url = lineMatch[1].trim().replace(/[.,;!?]+$/, '');
+    if (url && !urls.includes(url) && url.startsWith('http')) {
+      urls.push(url);
+    }
+  }
+
+  return urls;
+}
+
+/**
+ * Check if a URL has an archived version in the Wayback Machine
+ * Uses the Wayback Machine Availability API:
+ * https://archive.org/help/wayback_api.php
+ * @param {string} url - The URL to check
+ * @returns {Promise<{available: boolean, archiveUrl: string|null, timestamp: string|null}>}
+ */
+async function checkWaybackMachine(url) {
+  const apiUrl = `${WAYBACK_API}${encodeURIComponent(url)}`;
+
+  const controller = new AbortController();
+  const timeoutId = globalThis.setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const response = await fetch(apiUrl, {
+      headers: {
+        'User-Agent': 'broken-link-checker/1.0 (GitHub Actions CI)',
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      console.warn(`  Wayback API returned ${response.status} for ${url}`);
+      return { available: false, archiveUrl: null, timestamp: null };
+    }
+
+    const data = await response.json();
+
+    if (data.archived_snapshots?.closest?.available === true) {
+      const snapshot = data.archived_snapshots.closest;
+      const archiveUrl = snapshot.url.replace(/^http:\/\//, 'https://');
+      return {
+        available: true,
+        archiveUrl,
+        timestamp: snapshot.timestamp,
+      };
+    }
+
+    return { available: false, archiveUrl: null, timestamp: null };
+  } catch (error) {
+    console.warn(
+      `  Failed to check Wayback Machine for ${url}: ${error.message}`
+    );
+    return { available: false, archiveUrl: null, timestamp: null };
+  } finally {
+    globalThis.clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Format a timestamp from Wayback Machine (YYYYMMDDHHmmss) to readable date
+ * @param {string} timestamp - e.g. "20231015143022"
+ * @returns {string} - e.g. "2023-10-15"
+ */
+function formatTimestamp(timestamp) {
+  if (!timestamp || timestamp.length < 8) {
+    return timestamp;
+  }
+  const year = timestamp.slice(0, 4);
+  const month = timestamp.slice(4, 6);
+  const day = timestamp.slice(6, 8);
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  const lycheeOutput = process.env.LYCHEE_OUTPUT || 'lychee/out.md';
+
+  console.log('=== Web Archive Fallback Check ===\n');
+  console.log(`Reading lychee output from: ${lycheeOutput}\n`);
+
+  if (!existsSync(lycheeOutput)) {
+    console.log('No lychee output file found. Skipping web archive check.');
+    setOutput('all_archived', 'true');
+    process.exit(0);
+  }
+
+  const content = readFileSync(lycheeOutput, 'utf-8');
+  const brokenUrls = extractBrokenUrls(content);
+
+  if (brokenUrls.length === 0) {
+    console.log('No broken URLs found in lychee output.');
+    setOutput('all_archived', 'true');
+    process.exit(0);
+  }
+
+  console.log(
+    `Found ${brokenUrls.length} broken URL(s). Checking Web Archive...\n`
+  );
+
+  const withArchive = [];
+  const withoutArchive = [];
+
+  for (const url of brokenUrls) {
+    console.log(`Checking: ${url}`);
+    const result = await checkWaybackMachine(url);
+
+    if (result.available) {
+      const date = formatTimestamp(result.timestamp);
+      console.log(`  ✓ Archived on ${date}: ${result.archiveUrl}`);
+      withArchive.push({ url, archiveUrl: result.archiveUrl, date });
+    } else {
+      console.log('  ✗ Not found in Web Archive');
+      withoutArchive.push(url);
+    }
+
+    // Small delay to avoid rate-limiting the Wayback API
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 500));
+  }
+
+  console.log('\n=== Web Archive Check Summary ===\n');
+
+  if (withArchive.length > 0) {
+    console.log(
+      `✓ ${withArchive.length} broken link(s) have Web Archive versions - consider replacing:`
+    );
+    for (const { url, archiveUrl, date } of withArchive) {
+      console.log(`  Original: ${url}`);
+      console.log(`  Archive (${date}): ${archiveUrl}`);
+      console.log('');
+    }
+
+    // Print GitHub Actions annotations as suggestions (one per link)
+    for (const { url, archiveUrl, date } of withArchive) {
+      console.log(
+        `::notice title=Broken link - Web Archive available (${date})::` +
+          `Broken link detected: ${url}\n` +
+          `A Web Archive snapshot from ${date} is available.\n` +
+          `Suggested fix: replace the broken link with the archived version:\n` +
+          `  ${archiveUrl}`
+      );
+    }
+  }
+
+  if (withoutArchive.length > 0) {
+    console.log(
+      `✗ ${withoutArchive.length} broken link(s) have NO Web Archive version:`
+    );
+    for (const url of withoutArchive) {
+      console.log(`  ${url}`);
+    }
+    console.log('');
+
+    // Print GitHub Actions annotations as errors (one per link)
+    for (const url of withoutArchive) {
+      console.log(
+        `::error title=Broken link - No Web Archive fallback::` +
+          `Broken link detected: ${url}\n` +
+          `No archived version was found in the Wayback Machine.\n` +
+          `How to fix:\n` +
+          `  1. Find an updated URL for the same or equivalent content and replace the link.\n` +
+          `  2. Remove the link if the content is no longer relevant.\n` +
+          `  3. Add the URL to .lycheeignore if it is a known false positive (e.g. localhost, example.com).`
+      );
+    }
+  }
+
+  const allArchived = withoutArchive.length === 0;
+  setOutput('all_archived', allArchived ? 'true' : 'false');
+
+  if (!allArchived) {
+    console.log(
+      '\nAction required: Fix or remove the broken links listed above.'
+    );
+    console.log(
+      'For links with Web Archive versions, you can replace them with the suggested archive.org URLs.'
+    );
+    process.exit(1);
+  } else {
+    console.log(
+      '\nAll broken links have Web Archive versions. Consider replacing them with the suggested archive.org URLs.'
+    );
+    process.exit(0);
+  }
+}
+
+main().catch((error) => {
+  console.error('Unexpected error:', error);
+  process.exit(1);
+});

--- a/scripts/links-workflow-policy.test.mjs
+++ b/scripts/links-workflow-policy.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
 const LINKS_WORKFLOW = '.github/workflows/links.yml';
+const LYCHEE_IGNORE = '.lycheeignore';
 
 function readWorkflow() {
   return readFileSync(LINKS_WORKFLOW, 'utf-8').replaceAll('\r\n', '\n');
@@ -23,6 +24,12 @@ describe('broken-link workflow policy', () => {
 
     expect(workflow).toContain('--exclude-path docs/case-studies');
     expect(workflow).not.toContain('examples/universal-app/index.html');
+  });
+
+  test('ignores npm bot-protection responses', () => {
+    const ignoredUrls = readFileSync(LYCHEE_IGNORE, 'utf-8');
+
+    expect(ignoredUrls).toContain('https://www\\.npmjs\\.com');
   });
 
   test('uses a bounded, cancellation-safe Wayback fallback', () => {

--- a/scripts/links-workflow-policy.test.mjs
+++ b/scripts/links-workflow-policy.test.mjs
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const LINKS_WORKFLOW = '.github/workflows/links.yml';
+
+function readWorkflow() {
+  return readFileSync(LINKS_WORKFLOW, 'utf-8').replaceAll('\r\n', '\n');
+}
+
+describe('broken-link workflow policy', () => {
+  test('checks Markdown and HTML changes with least privilege', () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("name: Broken Link Checker");
+    expect(workflow).toContain("      - '**.md'");
+    expect(workflow).toContain("      - '**.html'");
+    expect(workflow).toContain('permissions:\n  contents: read');
+    expect(workflow).toContain('uses: lycheeverse/lychee-action@v2');
+  });
+
+  test('excludes copied case studies but not C# template HTML', () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain('--exclude-path docs/case-studies');
+    expect(workflow).not.toContain('examples/universal-app/index.html');
+  });
+
+  test('uses a bounded, cancellation-safe Wayback fallback', () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain('timeout-minutes: 10');
+    expect(workflow).toContain(
+      'group: check-${{ github.workflow }}-${{ github.ref }}-link-checker'
+    );
+    expect(workflow).toContain('cancel-in-progress: true');
+    expect(workflow).toContain('fail: false');
+    expect(workflow).toContain('run: node scripts/check-web-archive.mjs');
+    expect(workflow).toContain(
+      "if: steps.lychee.outputs.exit_code != 0 && steps.webarchive.outputs.all_archived != 'true'"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a path-filtered `Broken Link Checker` workflow for Markdown and HTML files
- run lychee with retries, caching, and the requested `docs/case-studies` exclusion
- check failed URLs against the Wayback Machine before failing with actionable guidance
- ignore npm's known 403 bot-protection response, matching the JS template policy
- add regression coverage for triggers, permissions, exclusions, concurrency, timeout, and fallback gating
- add a patch changeset for downstream template users

## Reproduction

Before this change, adding a known 404 link such as `[dead](https://example.com/definitely-not-a-page-404)` to `README.md` did not schedule any link-validation check, so CI could pass and merge the broken link.

The new workflow runs for `*.md` and `*.html` changes. Lychee records failures without immediately failing the job; the helper checks each failed URL for a Wayback snapshot, and the final gate fails when any URL has no archived fallback.

The policy regression test initially failed with `ENOENT` because `.github/workflows/links.yml` did not exist and now verifies the required workflow behavior.

## Verification

- `bun test scripts/*.test.mjs` (91 passed)
- `dotnet format --verify-no-changes`
- `dotnet build --configuration Release /warnaserror` (0 warnings, 0 errors)
- `dotnet test --no-build --configuration Release --verbosity normal` (21 passed)
- `bun run scripts/validate-changeset.mjs`
- `bun run scripts/check-file-size.mjs`
- missing-output helper smoke test
- `git diff --check`
- Broken Link Checker, CI/CD Pipeline, and Security workflows on `f6db62a`

Fixes #44
